### PR TITLE
state-sync txs inclusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,101 +196,10 @@ jobs:
           compression-level: 0
           if-no-files-found: error
 
-  test-release:
-    name: test on ${{ matrix.id }}
-    if: ${{ ! inputs.skip_tests }}
-    runs-on: [ self-hosted, qa, Release, "${{ matrix.runner-arch }}" ]
-    timeout-minutes: 2800  # 2 days
-    needs: [ build-release ]
-    strategy:
-      matrix:
-        include:
-          - id: linux/amd64
-            runner-arch: X64
-            artifact: linux_amd64
-          - id: linux/arm64
-            runner-arch: ARM64
-            artifact: linux_arm64
-
-    steps:
-
-      - name: Cleanup working directory
-        run: rm -drfv *
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Download artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar
-        uses: actions/download-artifact@v5
-        with:
-          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar
-          path: .
-
-      - name: Extract artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar
-        run: |
-          pwd
-          ls -l ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar
-          tar xvf ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar
-          ls -lR
-
-      - name: Fast checkout git repository erigontech/erigon-qa
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 ## 5.0.0
-        with:
-          token: ${{ secrets.ORG_GITHUB_ERIGONTECH_ERIGON_QA_READ }}
-          repository: erigontech/erigon-qa
-          fetch-depth: 1
-          ref: main
-          path: erigon-qa
-
-      - name: Run QA Tests
-        run: |
-          cd ./erigon-qa/test_system
-          pwd
-          ls -lao
-          pip3 install -r requirements.txt   
-          ln -s $(pwd)/base_library $(pwd)/qa-tests/tip-tracking/base_library
-          echo "DEBUG -- content of directory $(pwd) :"
-          ls -l
-          echo "DEBUG -- content of directory $(pwd)/qa-tests/tip-tracking/"
-          ls -l $(pwd)/qa-tests/tip-tracking/
-          echo "DEBUG -- content of directory GITHUB_WORKSPACE ${GITHUB_WORKSPACE} :"
-          ls -l ${GITHUB_WORKSPACE}
-          echo "DEBUG -- end."
-          rm -rf ${RUNNER_WORKSPACE}/erigon-data || true
-          mkdir ${RUNNER_WORKSPACE}/erigon-data
-          # Run Erigon, wait sync and check ability to maintain sync
-          python3 qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${GITHUB_WORKSPACE}/${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
-              ${RUNNER_WORKSPACE}/erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
-          # Capture monitoring script exit status
-          test_exit_status=$?
-          # Save the subsection reached status
-          echo "test_executed=true" >> "$GITHUB_OUTPUT"
-          # Check test runner script exit status
-          if [ $test_exit_status -eq 0 ]; then
-            echo "Tests completed successfully"
-            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "Error detected during tests"
-            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload Downloader Torrent Client Status
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: torrent-client-status-${{ matrix.artifact }}
-          path: torrent-client-status.txt
-
-      - name: Cleanup working directory
-        run: rm -drfv *
-
   build-debian-pkg:
     name: Debian packages
-    needs: [ build-release, test-release ]
-    if: always() && contains(needs.build-release.result, 'success') && !contains(needs.test-release.result, 'failure')
+    needs: [ build-release ]
+    if: always() && contains(needs.build-release.result, 'success')
     uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
     with:
       application: ${{ needs.build-release.outputs.application }}
@@ -298,11 +207,11 @@ jobs:
 
 
   publish-docker-image:
-    needs: [ build-release, test-release ]
-    if: always() && contains(needs.build-release.result, 'success') && !contains(needs.test-release.result, 'failure')
+    needs: [ build-release ]
+    if: always() && contains(needs.build-release.result, 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Docker image        
+    name: Docker image
 
     steps:
 
@@ -411,8 +320,8 @@ jobs:
 
   In-case-of-failure:
     name: "In case of failure: remove remote git tag pointing to the new version."
-    needs: [ publish-release, build-release, test-release, build-debian-pkg, publish-docker-image ]
-    if: always() && !contains(needs.build-release.result, 'success') && contains(needs.test-release.result, 'failure') && !contains(needs.publish-release.result, 'success') && !contains(needs.build-debian-pkg.result, 'success') && !contains(needs.publish-docker-image.result, 'success')
+    needs: [ publish-release, build-release, build-debian-pkg, publish-docker-image ]
+    if: always() && !contains(needs.build-release.result, 'success') && !contains(needs.publish-release.result, 'success') && !contains(needs.build-debian-pkg.result, 'success') && !contains(needs.publish-docker-image.result, 'success')
     runs-on: ubuntu-latest
 
     steps:

--- a/eth/ethutils/receipt.go
+++ b/eth/ethutils/receipt.go
@@ -96,6 +96,9 @@ func MarshalReceipt(
 		gasPrice := new(big.Int).Add(header.BaseFee, txn.GetEffectiveGasTip(baseFee).ToBig())
 		fields["effectiveGasPrice"] = (*hexutil.Big)(gasPrice)
 	}
+	if chainConfig.Bor != nil && txn.Type() == types.StateSyncTxType {
+		fields["effectiveGasPrice"] = (*hexutil.Big)(big.NewInt(0))
+	}
 
 	// Assign receipt status.
 	fields["status"] = hexutil.Uint64(receipt.Status)

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -181,6 +181,8 @@ type BorConfig interface {
 	GetBhilaiBlock() *big.Int
 	IsRio(num uint64) bool
 	GetRioBlock() *big.Int
+	IsStateSync(num uint64) bool
+	GetStateSyncBlock() *big.Int
 	StateReceiverContractAddress() common.Address
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
@@ -199,13 +201,14 @@ func (c *Config) String() string {
 	engine := c.getEngine()
 
 	if c.Bor != nil {
-		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Rio: %v, Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Rio: %v, StateSync: %v, Engine: %v}",
 			c.ChainID,
 			c.Bor.GetAgraBlock(),
 			c.Bor.GetNapoliBlock(),
 			c.Bor.GetAhmedabadBlock(),
 			c.Bor.GetBhilaiBlock(),
 			c.Bor.GetRioBlock(),
+			c.Bor.GetStateSyncBlock(),
 			engine,
 		)
 	}
@@ -703,6 +706,7 @@ type Rules struct {
 	IsCancun, IsNapoli, IsBhilai                      bool
 	IsPrague, IsOsaka                                 bool
 	IsAura                                            bool
+	IsStateSync                                       bool // TODO define a name when we have a fork that enables it
 }
 
 // isForked returns whether a fork scheduled at block s is active at the given head block.

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -410,6 +410,25 @@ func (pe *parallelExecutor) processResultQueue(ctx context.Context, inputTxNum u
 		}
 
 		if txTask.Final {
+			// PIP-74: ensure that logs from state-sync tx are applied
+			// this is needed as the state-sync txs are skipped during execution,
+			// but we still want to apply their logs to the state
+			if pe.cfg.chainConfig.Bor != nil && pe.cfg.chainConfig.Bor.IsStateSync(txTask.BlockNum) {
+				if len(txTask.BlockReceipts) > 0 {
+					last := txTask.BlockReceipts[len(txTask.BlockReceipts)-1]
+					if last != nil && last.Type == types.StateSyncTxType {
+						// Ensure logs from the state-sync receipt are applied
+						if err := pe.rs.ApplyLogsAndTraces(&state.TxTask{
+							BlockNum:      txTask.BlockNum,
+							BlockReceipts: []*types.Receipt{last},
+							Logs:          last.Logs,
+						}, pe.rs.Domains()); err != nil {
+							return outputTxNum, conflicts, triggers, processedBlockNum, false,
+								fmt.Errorf("ParallelExecutionState.Apply state-sync logs addition error: %w", err)
+						}
+					}
+				}
+			}
 			pe.rs.SetTxNum(txTask.TxNum, txTask.BlockNum)
 			err := pe.rs.ApplyState(ctx, txTask)
 			if err != nil {
@@ -528,6 +547,10 @@ func (pe *parallelExecutor) wait() error {
 
 func (pe *parallelExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp *core.GasPool) (bool, error) {
 	for _, txTask := range tasks {
+		// skip state sync txs
+		if txTask.Tx != nil && txTask.Tx.Type() == types.StateSyncTxType {
+			continue
+		}
 		if txTask.Sender() != nil {
 			if ok := pe.rs.RegisterSender(txTask); ok {
 				pe.rs.AddWork(ctx, txTask, pe.in)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -30,7 +30,7 @@ func (se *serialExecutor) wait() error {
 	return nil
 }
 
-func (se *serialExecutor) status(ctx context.Context, commitThreshold uint64) error {
+func (se *serialExecutor) status(_ context.Context, _ uint64) error {
 	return nil
 }
 
@@ -38,6 +38,10 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 	for _, txTask := range tasks {
 		if txTask.Error != nil {
 			return false, nil
+		}
+		// skip state sync txs
+		if txTask.Tx != nil && txTask.Tx.Type() == types.StateSyncTxType {
+			continue
 		}
 		if gp != nil {
 			se.applyWorker.SetGaspool(gp)
@@ -62,13 +66,23 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 
 			if txTask.Final {
 				if !se.isMining && !se.skipPostEvaluation && !se.execStage.CurrentSyncCycle.IsInitialCycle {
-					// note this assumes the bloach reciepts is a fixed array shared by
-					// all tasks - if that changes this will need to change - robably need to
+					// note this assumes the block receipts is a fixed array shared by
+					// all tasks - if that changes this will need to change - probably need to
 					// add this to the executor
-					se.cfg.notifications.RecentLogs.Add(txTask.BlockReceipts)
+					receiptsToPush := txTask.BlockReceipts
+					// polygon state-sync behavior
+					if se.cfg.chainConfig.Bor != nil && se.cfg.chainConfig.Bor.IsStateSync(txTask.BlockNum) {
+						// Nothing to do here
+						// Post StateSyncBlock (PIP-74), `FinalizeAndAssemble` already appends the state-sync receipt.
+						// It included in `receiptsToPush`, so we don't add it twice.
+						// Keeping the comment to make the state-sync handling explicit.
+					}
+					se.cfg.notifications.RecentLogs.Add(receiptsToPush)
 				}
 				checkReceipts := !se.cfg.vmConfig.StatelessExec && se.cfg.chainConfig.IsByzantium(txTask.BlockNum) && !se.cfg.vmConfig.NoReceipts && !se.isMining
-				if txTask.BlockNum > 0 && !se.skipPostEvaluation { //Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
+				if txTask.BlockNum > 0 && !se.skipPostEvaluation { // Disable check for genesis.
+					// Maybe we need to somehow improve it in the future
+					// to satisfy TestExecutionSpec
 					if err := core.BlockPostValidation(se.gasUsed, se.blobGasUsed, checkReceipts, txTask.BlockReceipts, txTask.Header, se.isMining, txTask.Txs, se.cfg.chainConfig, se.logger); err != nil {
 						return fmt.Errorf("%w, txnIdx=%d, %v", consensus.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
@@ -124,7 +138,7 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 			}
 		} else {
 			if se.cfg.chainConfig.Bor != nil && txTask.TxIndex >= 1 {
-				// get last receipt and store the last log index + 1
+				// get the last receipt and store the last log index + 1
 				lastReceipt := txTask.BlockReceipts[txTask.TxIndex-1]
 				if lastReceipt == nil {
 					if se.skipPostEvaluation {

--- a/execution/types/state_data.go
+++ b/execution/types/state_data.go
@@ -18,10 +18,10 @@ package types
 
 import "github.com/erigontech/erigon-lib/common"
 
-// StateSyncData represents state received from Ethereum Blockchain
+// StateSyncData represents state received from Ethereum Blockchain and stored in L2 via the StateSync mechanism.
 type StateSyncData struct {
 	ID       uint64
 	Contract common.Address
-	Data     string
-	TxHash   common.Hash
+	Data     []byte
+	TxHash   common.Hash // L1 TxHash
 }

--- a/execution/types/state_sync_tx.go
+++ b/execution/types/state_sync_tx.go
@@ -1,0 +1,276 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/big"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/crypto"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/rlp"
+
+	"github.com/holiman/uint256"
+)
+
+// StateSyncTx is the system transaction of Bor to introduce fetched state sync events from Heimdall
+type StateSyncTx struct {
+	StateSyncData []*StateSyncData
+}
+
+func (tx *StateSyncTx) Type() byte {
+	return StateSyncTxType
+}
+
+func (tx *StateSyncTx) GetChainID() *uint256.Int {
+	panic("chainID called from StateSyncTx")
+}
+
+func (tx *StateSyncTx) GetNonce() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) GetTipCap() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetEffectiveGasTip(_ *uint256.Int) *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetFeeCap() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetBlobHashes() []common.Hash {
+	return nil
+}
+
+func (tx *StateSyncTx) GetGasLimit() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) GetBlobGas() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) GetValue() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetTo() *common.Address {
+	return &common.Address{}
+}
+
+func (tx *StateSyncTx) AsMessage(_ Signer, baseFee *big.Int, rules *chain.Rules) (*Message, error) {
+	if !rules.IsStateSync {
+		// TODO change to better name when we have a hard fork for this
+		return nil, errors.New("pip-55: StateSync typed tx requires StateSync hard fork")
+	}
+	msg := Message{
+		nonce:      0,
+		gasLimit:   0,
+		gasPrice:   *uint256.NewInt(0),
+		tipCap:     *uint256.NewInt(0),
+		feeCap:     *uint256.NewInt(0),
+		to:         tx.GetTo(),
+		amount:     *uint256.NewInt(0),
+		data:       []byte{},
+		accessList: nil,
+		checkNonce: false,
+	}
+	if baseFee != nil {
+		_ = msg.gasPrice.SetFromBig(baseFee)
+	}
+
+	msg.from = common.Address{}
+	return &msg, nil
+}
+
+func (tx *StateSyncTx) WithSignature(_ Signer, _ []byte) (Transaction, error) {
+	return nil, errors.New("StateSyncTx are not signed")
+}
+
+func (tx *StateSyncTx) Hash() common.Hash {
+	// Serialize inner payload ([]StateSyncData)
+	var buf bytes.Buffer
+	// first write the type prefix
+	buf.WriteByte(StateSyncTxType)
+	// Then RLP-encode the slice
+	if err := tx.encode(&buf); err != nil {
+		panic("StateSyncTx encode failed: " + err.Error())
+	}
+	return crypto.Keccak256Hash(buf.Bytes())
+}
+
+func (tx *StateSyncTx) SigningHash(_ *big.Int) common.Hash {
+	// StateSync txs are never signed, return canonical hash
+	return tx.Hash()
+}
+
+func (tx *StateSyncTx) GetData() []byte {
+	return []byte{}
+}
+
+func (tx *StateSyncTx) GetAccessList() AccessList {
+	return nil
+}
+
+func (tx *StateSyncTx) GetAuthorizations() []Authorization {
+	return nil
+}
+
+func (tx *StateSyncTx) Protected() bool {
+	return true
+}
+
+func (tx *StateSyncTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int) {
+	return uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) EncodingSize() int {
+	var b bytes.Buffer
+	_ = tx.encode(&b)
+	return 1 + b.Len()
+}
+
+// EncodeRLP writes the inner payload ([]StateSyncData) without the type prefix.
+func (tx *StateSyncTx) EncodeRLP(w io.Writer) error {
+	if tx == nil {
+		return errors.New("nil StateSyncTx")
+	}
+	var buf bytes.Buffer
+	if err := tx.encode(&buf); err != nil {
+		return err
+	}
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// DecodeRLP consumes the RLP stream and populates tx.StateSyncData.
+// The type byte (0x7F) is already stripped by the UnmarshalTransaction path.
+func (tx *StateSyncTx) DecodeRLP(s *rlp.Stream) error {
+	raw, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return tx.decode(raw)
+}
+
+func (tx *StateSyncTx) MarshalBinary(w io.Writer) error {
+	if _, err := w.Write([]byte{StateSyncTxType}); err != nil {
+		return err
+	}
+	return tx.EncodeRLP(w)
+}
+
+func (tx *StateSyncTx) Sender(_ Signer) (common.Address, error) {
+	return common.Address{}, nil
+}
+
+func (tx *StateSyncTx) cachedSender() (common.Address, bool) {
+	return common.Address{}, false
+}
+
+func (tx *StateSyncTx) GetSender() (common.Address, bool) {
+	return common.Address{}, false
+}
+
+func (tx *StateSyncTx) SetSender(_ common.Address) {
+	// no-op, StateSyncTx has no sender
+}
+
+func (tx *StateSyncTx) IsContractDeploy() bool {
+	return false
+}
+
+func (tx *StateSyncTx) Unwrap() Transaction {
+	return tx
+}
+
+func (tx *StateSyncTx) copy() StateSyncTx {
+	if tx == nil {
+		return StateSyncTx{}
+	}
+	out := &StateSyncTx{}
+	if tx.StateSyncData != nil {
+		out.StateSyncData = make([]*StateSyncData, len(tx.StateSyncData))
+		for i, d := range tx.StateSyncData {
+			if d != nil {
+				c := *d
+				out.StateSyncData[i] = &c
+			} else {
+				out.StateSyncData[i] = nil
+			}
+		}
+	}
+	return *out
+}
+
+// accessors for innerTx.
+
+func (tx *StateSyncTx) effectiveGasPrice(_ *big.Int, _ *big.Int) *big.Int {
+	return big.NewInt(0)
+}
+
+func (tx *StateSyncTx) rawSignatureValues() (v, r, s *big.Int) {
+	panic("no signatures on StateSyncTx")
+}
+
+func (tx *StateSyncTx) setSignatureValues(_, _, _, _ *big.Int) {
+	panic("no sigs on StateSyncTx")
+}
+
+func (tx *StateSyncTx) encode(buf *bytes.Buffer) error {
+	if tx == nil {
+		return errors.New("nil StateSyncTx")
+	}
+	// Validate ascending and contiguous IDs as per PIP-55
+	var prev uint64
+	for i, d := range tx.StateSyncData {
+		if d == nil {
+			return errors.New("nil StateSyncData")
+		}
+		if i == 0 {
+			prev = d.ID
+		} else {
+			if d.ID != prev+1 {
+				return errors.New("stateSyncData IDs must be ascending and contiguous")
+			}
+			prev = d.ID
+		}
+	}
+	enc := make([]StateSyncData, 0, len(tx.StateSyncData))
+	for _, d := range tx.StateSyncData {
+		enc = append(enc, *d)
+	}
+	return rlp.Encode(buf, enc)
+}
+
+func (tx *StateSyncTx) decode(b []byte) error {
+	var dec []StateSyncData
+	if err := rlp.DecodeBytes(b, &dec); err != nil {
+		return err
+	}
+	// Validate ascending and contiguous IDs as per PIP-55
+	if len(dec) > 0 {
+		prev := dec[0].ID
+		for i := 1; i < len(dec); i++ {
+			if dec[i].ID != prev+1 {
+				return errors.New("stateSyncData IDs must be ascending and contiguous")
+			}
+			prev = dec[i].ID
+		}
+	}
+	tx.StateSyncData = make([]*StateSyncData, len(dec))
+	for i := range dec {
+		d := dec[i]
+		tx.StateSyncData[i] = &d
+	}
+	return nil
+}
+
+func (tx *StateSyncTx) sigHash(_ *big.Int) common.Hash {
+	panic("StateSyncTx has no sigHash")
+}

--- a/execution/types/state_sync_tx.go
+++ b/execution/types/state_sync_tx.go
@@ -66,7 +66,7 @@ func (tx *StateSyncTx) GetTo() *common.Address {
 func (tx *StateSyncTx) AsMessage(_ Signer, baseFee *big.Int, rules *chain.Rules) (*Message, error) {
 	if !rules.IsStateSync {
 		// TODO change to better name when we have a hard fork for this
-		return nil, errors.New("pip-55: StateSync typed tx requires StateSync hard fork")
+		return nil, errors.New("StateSync typed tx requires StateSync hard fork")
 	}
 	msg := Message{
 		nonce:      0,
@@ -226,7 +226,7 @@ func (tx *StateSyncTx) encode(buf *bytes.Buffer) error {
 	if tx == nil {
 		return errors.New("nil StateSyncTx")
 	}
-	// Validate ascending and contiguous IDs as per PIP-55
+	// Validate ascending and contiguous IDs as per PIP-74
 	var prev uint64
 	for i, d := range tx.StateSyncData {
 		if d == nil {
@@ -253,7 +253,7 @@ func (tx *StateSyncTx) decode(b []byte) error {
 	if err := rlp.DecodeBytes(b, &dec); err != nil {
 		return err
 	}
-	// Validate ascending and contiguous IDs as per PIP-55
+	// Validate ascending and contiguous IDs as per PIP-74
 	if len(dec) > 0 {
 		prev := dec[0].ID
 		for i := 1; i < len(dec); i++ {

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -54,6 +54,7 @@ const (
 	BlobTxType
 	SetCodeTxType
 	AccountAbstractionTxType
+	StateSyncTxType = 127
 )
 
 // Transaction is an Ethereum transaction.
@@ -105,7 +106,8 @@ type TransactionMisc struct {
 	from atomic.Pointer[common.Address]
 }
 
-// RLP-marshalled legacy transactions and binary-marshalled (not wrapped into an RLP string) typed (EIP-2718) transactions
+// BinaryTransactions is the RLP-marshaled legacy transactions and binary-marshaled
+// (not wrapped into an RLP string) typed (EIP-2718) transactions
 type BinaryTransactions [][]byte
 
 func (t BinaryTransactions) Len() int {
@@ -179,7 +181,7 @@ func DecodeTransaction(data []byte) (Transaction, error) {
 	return tx, nil
 }
 
-// Parse transaction without envelope.
+// UnmarshalTransactionFromBinary parses the transaction without the envelope.
 func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs bool) (Transaction, error) {
 	if len(data) <= 1 {
 		return nil, fmt.Errorf("short input: %v", len(data))
@@ -202,6 +204,8 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 		t = &SetCodeTransaction{}
 	case AccountAbstractionTxType:
 		t = &AccountAbstractionTransaction{}
+	case StateSyncTxType:
+		t = &StateSyncTx{}
 	default:
 		if data[0] >= 0x80 {
 			// txn is type legacy which is RLP encoded
@@ -218,7 +222,7 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 	return t, nil
 }
 
-// Removes everything but the payload body from blob tx and prepends 0x3 at the beginning - no copy
+// UnwrapTxPlayloadRlp removes everything but the payload body from blob tx and prepends 0x3 at the beginning - no copy
 // Doesn't change non-blob tx
 func UnwrapTxPlayloadRlp(blobTxRlp []byte) ([]byte, error) {
 	if blobTxRlp[0] != BlobTxType {

--- a/execution/types/transaction_marshalling.go
+++ b/execution/types/transaction_marshalling.go
@@ -62,6 +62,9 @@ type txJSON struct {
 	Commitments BlobKzgs  `json:"commitments,omitempty"`
 	Proofs      KZGProofs `json:"proofs,omitempty"`
 
+	// StateSync transaction fields:
+	StateSyncData *[]*StateSyncData `json:"stateSyncData,omitempty"`
+
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
 }
@@ -209,6 +212,35 @@ func (tx *BlobTxWrapper) MarshalJSON() ([]byte, error) {
 	return json.Marshal(enc)
 }
 
+// MarshalJSON for StateSyncTx serializes it as a zero-valued, unsigned system transaction.
+// This ensures eth_getBlockBy* returns it in the transaction list.
+func (tx *StateSyncTx) MarshalJSON() ([]byte, error) {
+	var enc txJSON
+	enc.Hash = tx.Hash()
+	enc.Type = hexutil.Uint64(tx.Type())
+
+	zero := hexutil.Uint64(0)
+	zeroBig := (*hexutil.Big)(big.NewInt(0))
+
+	enc.Nonce = &zero
+	enc.Gas = &zero
+	enc.GasPrice = zeroBig
+	enc.MaxFeePerGas = zeroBig
+	enc.MaxPriorityFeePerGas = zeroBig
+	enc.Value = zeroBig
+	empty := hexutil.Bytes{}
+	enc.Data = &empty
+	zeroAddr := common.Address{}
+	enc.To = &zeroAddr
+
+	// include state sync payload
+	if len(tx.StateSyncData) > 0 {
+		enc.StateSyncData = &tx.StateSyncData
+	}
+
+	return json.Marshal(&enc)
+}
+
 func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 	var p fastjson.Parser
 	v, err := p.ParseBytes(input)
@@ -250,6 +282,12 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 		return tx, nil
 	case SetCodeTxType:
 		tx := &SetCodeTransaction{}
+		if err = tx.UnmarshalJSON(input); err != nil {
+			return nil, err
+		}
+		return tx, nil
+	case StateSyncTxType:
+		tx := &StateSyncTx{}
 		if err = tx.UnmarshalJSON(input); err != nil {
 			return nil, err
 		}
@@ -623,4 +661,26 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 		return nil, err
 	}
 	return &btx, nil
+}
+
+// UnmarshalJSON for StateSyncTx decodes from the generic txJSON wrapper.
+// Unlike user-submitted txs, StateSyncTx has no nonce/gas/value/signature.
+// We only restore StateSyncData if present.
+func (tx *StateSyncTx) UnmarshalJSON(input []byte) error {
+	var dec txJSON
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if byte(dec.Type) != StateSyncTxType {
+		return fmt.Errorf("invalid type for StateSyncTx: %v", dec.Type)
+	}
+
+	// Parse the StateSyncData if present in JSON
+	if dec.StateSyncData != nil {
+		tx.StateSyncData = *dec.StateSyncData
+	} else {
+		tx.StateSyncData = nil
+	}
+
+	return nil
 }

--- a/execution/types/transaction_test.go
+++ b/execution/types/transaction_test.go
@@ -815,3 +815,266 @@ func TestTrailingBytes(t *testing.T) {
 		panic("Malicious transaction has not errored!") // @audit this panic is occurs
 	}
 }
+
+func TestStateSyncTx_HashAndSigningHash(t *testing.T) {
+	t.Parallel()
+	ss := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 1, Contract: testAddr, Data: []byte("foo"), TxHash: randHash()},
+			{ID: 2, Contract: testAddr, Data: []byte("bar"), TxHash: randHash()},
+		},
+	}
+	h1 := ss.Hash()
+	h2 := ss.SigningHash(nil)
+
+	if h1 != h2 {
+		t.Fatalf("expected SigningHash == Hash, got %x vs %x", h1, h2)
+	}
+	if (h1 == common.Hash{}) {
+		t.Fatal("hash must not be empty")
+	}
+}
+
+func TestStateSyncTx_RLPRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 10, Contract: testAddr, Data: []byte("payload"), TxHash: randHash()},
+			{ID: 11, Contract: testAddr, Data: []byte("payload2"), TxHash: randHash()},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := orig.MarshalBinary(&buf); err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	decoded, err := DecodeTransaction(buf.Bytes())
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	ss2, ok := decoded.(*StateSyncTx)
+	if !ok {
+		t.Fatalf("decoded wrong type: %T", decoded)
+	}
+
+	// hashes must match
+	if orig.Hash() != ss2.Hash() {
+		t.Fatalf("hash mismatch, orig %x, got %x", orig.Hash(), ss2.Hash())
+	}
+	// data length must match
+	if len(ss2.StateSyncData) != len(orig.StateSyncData) {
+		t.Fatalf("state sync data mismatch, want %d, got %d", len(orig.StateSyncData), len(ss2.StateSyncData))
+	}
+}
+
+func TestStateSyncTx_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 42, Contract: testAddr, Data: []byte("baz"), TxHash: randHash()},
+		},
+	}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("json marshal failed: %v", err)
+	}
+	tx2, err := UnmarshalTransactionFromJSON(data)
+	if err != nil {
+		t.Fatalf("json unmarshal failed: %v", err)
+	}
+	ss2, ok := tx2.(*StateSyncTx)
+	if !ok {
+		t.Fatalf("decoded wrong type: %T", tx2)
+	}
+	if ss2.Hash() != orig.Hash() {
+		t.Fatalf("hash mismatch after JSON round-trip")
+	}
+	if len(ss2.StateSyncData) != 1 || ss2.StateSyncData[0].ID != 42 {
+		t.Fatalf("unexpected state sync data after JSON round-trip: %+v", ss2.StateSyncData)
+	}
+}
+
+func TestStateSyncTx_InvalidIDs(t *testing.T) {
+	t.Parallel()
+	ss := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 5, Contract: testAddr, Data: []byte("a"), TxHash: randHash()},
+			{ID: 7, Contract: testAddr, Data: []byte("b"), TxHash: randHash()}, // gap, 6 is missing
+		},
+	}
+	var buf bytes.Buffer
+	err := ss.encode(&buf)
+	if err == nil {
+		t.Fatal("expected error due to non-contiguous IDs, got nil")
+	}
+}
+
+func TestStateSyncTx_HashSensitivity(t *testing.T) {
+	base := makeBaseStateSyncTx()
+
+	hashOf := func(mutate func(*StateSyncTx)) common.Hash {
+		// deep copy
+		st := &StateSyncTx{StateSyncData: make([]*StateSyncData, len(base.StateSyncData))}
+		for i, e := range base.StateSyncData {
+			if e != nil {
+				c := *e
+				st.StateSyncData[i] = &c
+			}
+		}
+		if mutate != nil {
+			mutate(st)
+		}
+		return st.Hash()
+	}
+
+	baseHash := hashOf(nil)
+
+	if got := hashOf(nil); got != baseHash {
+		t.Fatalf("determinism failed: %x vs %x", baseHash, got)
+	}
+
+	// Only mutations that respect contiguous IDs
+	cases := []struct {
+		name   string
+		mutate func(*StateSyncTx)
+	}{
+		{"change Contract", func(st *StateSyncTx) {
+			st.StateSyncData[0].Contract = common.HexToAddress("0x000000000000000000000000000000000000CAFE")
+		}},
+		{"change Data", func(st *StateSyncTx) {
+			st.StateSyncData[0].Data = []byte("alpha-mutated")
+		}},
+		{"change TxHash", func(st *StateSyncTx) {
+			st.StateSyncData[0].TxHash = common.HexToHash("0xAAAA")
+		}},
+		{"mutate second entry", func(st *StateSyncTx) {
+			st.StateSyncData[1].Contract = common.HexToAddress("0x000000000000000000000000000000000000BEEF")
+			st.StateSyncData[1].Data = []byte("beta-mutated")
+			st.StateSyncData[1].TxHash = common.HexToHash("0xBBBB")
+		}},
+		{"append new entry contiguous ID", func(st *StateSyncTx) {
+			st.StateSyncData = append(st.StateSyncData, &StateSyncData{
+				ID:       3, // contiguous after 1,2
+				Contract: common.HexToAddress("0x0000000000000000000000000000000000001003"),
+				Data:     []byte("gamma"),
+				TxHash:   common.HexToHash("0x3333"),
+			})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hashOf(tc.mutate); got == baseHash {
+				t.Fatalf("%s: hash did not change (base=%x, got=%x)", tc.name, baseHash, got)
+			}
+		})
+	}
+}
+
+func TestStateSyncTx_EncodeDecode_RoundTrip(t *testing.T) {
+	orig := makeBaseStateSyncTx()
+
+	var buf bytes.Buffer
+	if err := orig.encode(&buf); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	enc := buf.Bytes()
+
+	var rt StateSyncTx
+	if err := rt.decode(enc); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(orig, &rt) {
+		t.Fatalf("round-trip mismatch:\n  orig=%#v\n  rt=%#v", orig, &rt)
+	}
+
+	var buf2 bytes.Buffer
+	if err := rt.encode(&buf2); err != nil {
+		t.Fatalf("re-encode failed: %v", err)
+	}
+	if !bytes.Equal(enc, buf2.Bytes()) {
+		t.Fatalf("encode not deterministic: first=%x second=%x", enc, buf2.Bytes())
+	}
+}
+
+func TestStateSyncTx_Encode_FailsOnNilEntry(t *testing.T) {
+	withNil := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 1, Contract: testAddr, Data: []byte("alpha"), TxHash: randHash()},
+			nil, // encoder should reject this
+			{ID: 2, Contract: testAddr, Data: []byte("beta"), TxHash: randHash()},
+		},
+	}
+	var buf bytes.Buffer
+	err := withNil.encode(&buf)
+	if err == nil {
+		t.Fatalf("expected encode to fail on nil entry, got no error")
+	}
+}
+
+func TestStateSyncTx_EncodeDecode_Empty(t *testing.T) {
+	var empty StateSyncTx
+	var buf bytes.Buffer
+
+	if err := empty.encode(&buf); err != nil {
+		t.Fatalf("encode(empty) failed: %v", err)
+	}
+	var rt StateSyncTx
+	if err := rt.decode(buf.Bytes()); err != nil {
+		t.Fatalf("decode(empty) failed: %v", err)
+	}
+	if rt.StateSyncData == nil || len(rt.StateSyncData) != 0 {
+		t.Fatalf("expected empty slice, got %#v", rt.StateSyncData)
+	}
+}
+
+func TestStateSyncTx_Decode_Garbage(t *testing.T) {
+	var rt StateSyncTx
+	if err := rt.decode([]byte{0x01, 0x02, 0x03}); err == nil {
+		t.Fatalf("expected error on garbage decode")
+	}
+}
+
+func TestStateSyncTx_Encode_DeterministicAcrossCopies(t *testing.T) {
+	orig := makeBaseStateSyncTx()
+
+	// manual deep copy
+	clone := &StateSyncTx{StateSyncData: make([]*StateSyncData, len(orig.StateSyncData))}
+	for i, e := range orig.StateSyncData {
+		if e != nil {
+			c := *e
+			clone.StateSyncData[i] = &c
+		}
+	}
+
+	var b1, b2 bytes.Buffer
+	if err := orig.encode(&b1); err != nil {
+		t.Fatalf("encode(orig) failed: %v", err)
+	}
+	if err := clone.encode(&b2); err != nil {
+		t.Fatalf("encode(clone) failed: %v", err)
+	}
+	if !bytes.Equal(b1.Bytes(), b2.Bytes()) {
+		t.Fatalf("encode not deterministic across copies: enc1=%x enc2=%x", b1.Bytes(), b2.Bytes())
+	}
+}
+
+func makeBaseStateSyncTx() *StateSyncTx {
+	return &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{
+				ID:       1,
+				Contract: common.HexToAddress("0x0000000000000000000000000000000000001001"),
+				Data:     []byte("alpha"),
+				TxHash:   common.HexToHash("0x1111"),
+			},
+			{
+				ID:       2,
+				Contract: common.HexToAddress("0x0000000000000000000000000000000000001002"),
+				Data:     []byte("beta"),
+				TxHash:   common.HexToHash("0x2222"),
+			},
+		},
+	}
+}

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -309,9 +309,6 @@ type Bor struct {
 	logger         log.Logger
 	rootHashCache  *lru.ARCCache[string, string]
 	headerProgress HeaderProgress
-
-	// executed in CommitStates when rules.IsStateSync is true
-	lastStateSyncData []*types.StateSyncData
 }
 
 type signer struct {
@@ -827,8 +824,10 @@ func (c *Bor) Finalize(_ *chain.Config, header *types.Header, state *state.Intra
 				}
 			}
 
-			// commit states
-			if err := c.CommitStates(header, cx, syscall, false); err != nil {
+			// Commit States
+			// Unlike `FinalizeAndAssemble`, we do not use the returned StateSyncData here,
+			// since receipts/tx assembly happens only in FinalizeAndAssemble.
+			if _, err := c.CommitStates(header, cx, syscall, false); err != nil {
 				err := fmt.Errorf("Finalize.CommitStates: %w", err)
 				c.logger.Error("[bor] Error while committing states", "err", err)
 				return nil, err
@@ -866,9 +865,18 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state *state.Intra
 
 // FinalizeAndAssemble implements consensus.Engine, ensuring no uncles are set,
 // nor block rewards given, and returns the final block.
-func (c *Bor) FinalizeAndAssemble(_ *chain.Config, header *types.Header, state *state.IntraBlockState,
-	txs types.Transactions, _ []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal,
-	chain consensus.ChainReader, syscall consensus.SystemCall, _ consensus.Call, _ log.Logger,
+func (c *Bor) FinalizeAndAssemble(
+	_ *chain.Config,
+	header *types.Header,
+	state *state.IntraBlockState,
+	txs types.Transactions,
+	_ []*types.Header,
+	receipts types.Receipts,
+	withdrawals []*types.Withdrawal,
+	chain consensus.ChainReader,
+	syscall consensus.SystemCall,
+	_ consensus.Call,
+	_ log.Logger,
 ) (*types.Block, types.FlatRequests, error) {
 	headerNumber := header.Number.Uint64()
 
@@ -879,6 +887,8 @@ func (c *Bor) FinalizeAndAssemble(_ *chain.Config, header *types.Header, state *
 	if header.RequestsHash != nil {
 		return nil, nil, consensus.ErrUnexpectedRequests
 	}
+
+	var execStateSync []*types.StateSyncData
 
 	if c.config.IsSprintStart(headerNumber) {
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
@@ -893,8 +903,10 @@ func (c *Bor) FinalizeAndAssemble(_ *chain.Config, header *types.Header, state *
 					return nil, nil, err
 				}
 			}
-			// commit states
-			if err := c.CommitStates(header, cx, syscall, true); err != nil {
+			// commit states, get executed state sync data
+			var err error
+			execStateSync, err = c.CommitStates(header, cx, syscall, true)
+			if err != nil {
 				err := fmt.Errorf("FinalizeAndAssemble.CommitStates: %w", err)
 				c.logger.Error("[bor] committing states", "err", err)
 				return nil, nil, err
@@ -908,13 +920,11 @@ func (c *Bor) FinalizeAndAssemble(_ *chain.Config, header *types.Header, state *
 	}
 
 	// PIP-74: append StateSyncTx and receipt post-fork if any events executed
-	if c.config.IsStateSync(headerNumber) {
-		if stateSyncData := c.popLastStateSyncData(); len(stateSyncData) > 0 {
-			stateSyncTx := &types.StateSyncTx{StateSyncData: stateSyncData}
-			txs = append(txs, stateSyncTx)
-			stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
-			receipts = append(receipts, stateSyncReceipt)
-		}
+	if c.config.IsStateSync(headerNumber) && len(execStateSync) > 0 {
+		stateSyncTx := &types.StateSyncTx{StateSyncData: execStateSync}
+		txs = append(txs, stateSyncTx)
+		stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
+		receipts = append(receipts, stateSyncReceipt)
 	}
 
 	return types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals), nil, nil
@@ -1231,12 +1241,13 @@ func (c *Bor) getHeaderByNumber(ctx context.Context, tx kv.Tx, number uint64) (*
 }
 
 // CommitStates commit states
+// It also executes the state-sync-related events and returns those as StateSyncData
 func (c *Bor) CommitStates(
 	header *types.Header,
 	chain statefull.ChainContext,
 	syscall consensus.SystemCall,
 	fetchEventsWithinTime bool,
-) error {
+) ([]*types.StateSyncData, error) {
 	blockNum := header.Number.Uint64()
 	var events []*types.Message
 	var err error
@@ -1246,7 +1257,7 @@ func (c *Bor) CommitStates(
 		sprintLength := c.config.CalculateSprintLength(blockNum)
 
 		if blockNum < sprintLength {
-			return nil
+			return nil, nil
 		}
 
 		prevSprintStart := chain.Chain.GetHeaderByNumber(blockNum - sprintLength)
@@ -1272,20 +1283,20 @@ func (c *Bor) CommitStates(
 
 		events, err = c.bridgeReader.EventsWithinTime(ctx, timeFrom, timeTo)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		events, err = c.bridgeReader.Events(ctx, header.Hash(), blockNum)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	executed := make([]*types.StateSyncData, 0, len(events))
+	execStateSync := make([]*types.StateSyncData, 0, len(events))
 
 	for _, event := range events {
 		if _, err := syscall(*event.To(), event.Data()); err != nil {
-			return err
+			return nil, err
 		}
 
 		var ev types.StateSyncData
@@ -1293,7 +1304,7 @@ func (c *Bor) CommitStates(
 			continue // not a state-sync event, skip
 		}
 
-		executed = append(executed, &types.StateSyncData{
+		execStateSync = append(execStateSync, &types.StateSyncData{
 			ID:       ev.ID,
 			Contract: ev.Contract,
 			Data:     ev.Data,
@@ -1301,16 +1312,9 @@ func (c *Bor) CommitStates(
 		})
 	}
 
-	// PIP-74: if the StateSync fork is active, stash executed events
-	if c.config.IsStateSync(blockNum) {
-		if len(executed) > 0 {
-			c.lastStateSyncData = executed
-		} else {
-			c.lastStateSyncData = nil
-		}
-	}
-
-	return nil
+	// Return the executed events
+	// This is harmless pre-fork, because the caller will decide whether to use it or not, based on HF status.
+	return execStateSync, nil
 }
 
 // BorTransfer transfer in Bor
@@ -1441,12 +1445,6 @@ func VerifyUncles(uncles []*types.Header) error {
 	}
 
 	return nil
-}
-
-func (c *Bor) popLastStateSyncData() []*types.StateSyncData {
-	out := c.lastStateSyncData
-	c.lastStateSyncData = nil
-	return out
 }
 
 // newStateSyncReceipt creates a new receipt for the StateSyncTx

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -841,7 +841,7 @@ func (c *Bor) Finalize(_ *chain.Config, header *types.Header, state *state.Intra
 		return nil, err
 	}
 
-	// PIP-55: Finalize does not append txs/receipts (that’s done in FinalizeAndAssemble)
+	// PIP-74: Finalize does not append txs/receipts (that’s done in FinalizeAndAssemble)
 
 	return nil, nil
 }
@@ -907,7 +907,7 @@ func (c *Bor) FinalizeAndAssemble(_ *chain.Config, header *types.Header, state *
 		return nil, nil, err
 	}
 
-	// PIP-55: append StateSyncTx and receipt post-fork if any events executed
+	// PIP-74: append StateSyncTx and receipt post-fork if any events executed
 	if c.config.IsStateSync(headerNumber) {
 		if stateSyncData := c.popLastStateSyncData(); len(stateSyncData) > 0 {
 			stateSyncTx := &types.StateSyncTx{StateSyncData: stateSyncData}
@@ -1301,7 +1301,7 @@ func (c *Bor) CommitStates(
 		})
 	}
 
-	// PIP-55: if the StateSync fork is active, stash executed events
+	// PIP-74: if the StateSync fork is active, stash executed events
 	if c.config.IsStateSync(blockNum) {
 		if len(executed) > 0 {
 			c.lastStateSyncData = executed

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -827,9 +827,10 @@ func (c *Bor) Finalize(_ *chain.Config, header *types.Header, state *state.Intra
 			// Commit States
 			// Unlike `FinalizeAndAssemble`, we do not use the returned StateSyncData here,
 			// since receipts/tx assembly happens only in FinalizeAndAssemble.
+			c.logger.Info(">>>>> FINALIZE: Committing states for block", "number", header.Number, "hash", header.Hash())
 			if _, err := c.CommitStates(header, cx, syscall, false); err != nil {
 				err := fmt.Errorf("Finalize.CommitStates: %w", err)
-				c.logger.Error("[bor] Error while committing states", "err", err)
+				c.logger.Error(">>>>> [bor] Error while committing states", "err", err)
 				return nil, err
 			}
 		}
@@ -920,11 +921,23 @@ func (c *Bor) FinalizeAndAssemble(
 	}
 
 	// PIP-74: append StateSyncTx and receipt post-fork if any events executed
-	if c.config.IsStateSync(headerNumber) && len(execStateSync) > 0 {
-		stateSyncTx := &types.StateSyncTx{StateSyncData: execStateSync}
-		txs = append(txs, stateSyncTx)
-		stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
-		receipts = append(receipts, stateSyncReceipt)
+	c.logger.Info(">>>>> FinalizeAndAssemble: Assembling block", "number", header.Number, "hash", header.Hash(), "TxCount", len(txs), "StateSyncCount", len(execStateSync), "ReceiptCount", len(receipts))
+	if c.config.IsStateSync(headerNumber) {
+		c.logger.Info(">>>>> FinalizeAndAssemble: IsStateSync YES")
+		if len(execStateSync) > 0 {
+			c.logger.Info(">>>>> FinalizeAndAssemble: execStateSync length > 0")
+			c.logger.Info(">>>>> FinalizeAndAssemble: Appending state sync txs", "count", len(execStateSync))
+			stateSyncTx := &types.StateSyncTx{StateSyncData: execStateSync}
+			txs = append(txs, stateSyncTx)
+			c.logger.Info(">>>>> FinalizeAndAssemble: About to call newStateSyncReceipt")
+			stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
+			c.logger.Info(">>>>> FinalizeAndAssemble: Called newStateSyncReceipt", "receipt", stateSyncReceipt)
+			receipts = append(receipts, stateSyncReceipt)
+		} else {
+			c.logger.Info(">>>>> FinalizeAndAssemble: execStateSync length == 0")
+		}
+	} else {
+		c.logger.Info(">>>>> FinalizeAndAssemble: IsStateSync NO")
 	}
 
 	return types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals), nil, nil
@@ -1294,6 +1307,7 @@ func (c *Bor) CommitStates(
 
 	execStateSync := make([]*types.StateSyncData, 0, len(events))
 
+	c.logger.Info(">>>>> Committing states", "block", blockNum, "events", len(events))
 	for _, event := range events {
 		if _, err := syscall(*event.To(), event.Data()); err != nil {
 			return nil, err
@@ -1304,6 +1318,7 @@ func (c *Bor) CommitStates(
 			continue // not a state-sync event, skip
 		}
 
+		c.logger.Info(">>>>> Executed state sync event", "id", ev.ID, "contract", ev.Contract.Hex(), "txHash", ev.TxHash.Hex())
 		execStateSync = append(execStateSync, &types.StateSyncData{
 			ID:       ev.ID,
 			Contract: ev.Contract,

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -827,10 +827,9 @@ func (c *Bor) Finalize(_ *chain.Config, header *types.Header, state *state.Intra
 			// Commit States
 			// Unlike `FinalizeAndAssemble`, we do not use the returned StateSyncData here,
 			// since receipts/tx assembly happens only in FinalizeAndAssemble.
-			c.logger.Info(">>>>> FINALIZE: Committing states for block", "number", header.Number, "hash", header.Hash())
 			if _, err := c.CommitStates(header, cx, syscall, false); err != nil {
 				err := fmt.Errorf("Finalize.CommitStates: %w", err)
-				c.logger.Error(">>>>> [bor] Error while committing states", "err", err)
+				c.logger.Error("[bor] Error while committing states", "err", err)
 				return nil, err
 			}
 		}
@@ -921,23 +920,12 @@ func (c *Bor) FinalizeAndAssemble(
 	}
 
 	// PIP-74: append StateSyncTx and receipt post-fork if any events executed
-	c.logger.Info(">>>>> FinalizeAndAssemble: Assembling block", "number", header.Number, "hash", header.Hash(), "TxCount", len(txs), "StateSyncCount", len(execStateSync), "ReceiptCount", len(receipts))
-	if c.config.IsStateSync(headerNumber) {
-		c.logger.Info(">>>>> FinalizeAndAssemble: IsStateSync YES")
-		if len(execStateSync) > 0 {
-			c.logger.Info(">>>>> FinalizeAndAssemble: execStateSync length > 0")
-			c.logger.Info(">>>>> FinalizeAndAssemble: Appending state sync txs", "count", len(execStateSync))
-			stateSyncTx := &types.StateSyncTx{StateSyncData: execStateSync}
-			txs = append(txs, stateSyncTx)
-			c.logger.Info(">>>>> FinalizeAndAssemble: About to call newStateSyncReceipt")
-			stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
-			c.logger.Info(">>>>> FinalizeAndAssemble: Called newStateSyncReceipt", "receipt", stateSyncReceipt)
-			receipts = append(receipts, stateSyncReceipt)
-		} else {
-			c.logger.Info(">>>>> FinalizeAndAssemble: execStateSync length == 0")
-		}
-	} else {
-		c.logger.Info(">>>>> FinalizeAndAssemble: IsStateSync NO")
+	if c.config.IsStateSync(headerNumber) && len(execStateSync) > 0 {
+		c.logger.Info("FinalizeAndAssemble: Appending state sync txs", "count", len(execStateSync))
+		stateSyncTx := &types.StateSyncTx{StateSyncData: execStateSync}
+		txs = append(txs, stateSyncTx)
+		stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
+		receipts = append(receipts, stateSyncReceipt)
 	}
 
 	return types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals), nil, nil
@@ -1307,7 +1295,6 @@ func (c *Bor) CommitStates(
 
 	execStateSync := make([]*types.StateSyncData, 0, len(events))
 
-	c.logger.Info(">>>>> Committing states", "block", blockNum, "events", len(events))
 	for _, event := range events {
 		if _, err := syscall(*event.To(), event.Data()); err != nil {
 			return nil, err
@@ -1318,7 +1305,6 @@ func (c *Bor) CommitStates(
 			continue // not a state-sync event, skip
 		}
 
-		c.logger.Info(">>>>> Executed state sync event", "id", ev.ID, "contract", ev.Contract.Hex(), "txHash", ev.TxHash.Hex())
 		execStateSync = append(execStateSync, &types.StateSyncData{
 			ID:       ev.ID,
 			Contract: ev.Contract,

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -67,13 +67,13 @@ const inmemorySignatures = 4096 // Number of recent block signatures to keep in 
 var (
 	// Default number of blocks after which to checkpoint and reset the pending votes
 	defaultSprintLength        = map[string]uint64{"0": 64}
-	validatorHeaderBytesLength = length.Addr + 20 // address + power
+	validatorHeaderBytesLength = length.Addr + 20 // address and power
 	// maxCheckpointLength is the maximum number of blocks that can be requested for constructing a checkpoint root hash
 	maxCheckpointLength = uint64(math.Pow(2, 15))
 )
 
 // Various error messages to mark blocks invalid. These should be private to
-// prevent engine specific errors from being referenced in the remainder of the
+// prevent the engine-specific errors from being referenced in the remainder of the
 // codebase, inherently breaking if the engine is swapped out. Please put common
 // error types into the consensus package.
 var (
@@ -86,20 +86,20 @@ var (
 	// errMissingSignature is returned if a block's extra-data section doesn't seem
 	// to contain a 65 byte secp256k1 signature.
 	errMissingSignature = errors.New("extra-data 65 byte signature suffix missing")
-	// errExtraValidators is returned if non-sprint-end block contain validator data in
+	// errExtraValidators is returned if non-sprint-end block contains validator data in
 	// their extra-data fields.
 	errExtraValidators = errors.New("non-sprint-end block contains extra validator list")
 	// errInvalidSprintValidators is returned if a block contains an
-	// invalid list of validators (i.e. non divisible by 40 bytes).
+	// invalid list of validators (i.e., non-divisible by 40 bytes).
 	errInvalidSprintValidators = errors.New("invalid validator list on sprint end block")
 	// errInvalidMixDigest is returned if a block's mix digest is non-zero.
 	errInvalidMixDigest = errors.New("non-zero mix digest")
-	// errInvalidUncleHash is returned if a block contains an non-empty uncle list.
+	// errInvalidUncleHash is returned if a block contains a non-empty uncle list.
 	errInvalidUncleHash = errors.New("non empty uncle hash")
-	// errInvalidDifficulty is returned if the difficulty of a block neither 1 or 2.
+	// errInvalidDifficulty is returned if the difficulty of a block neither 1 nor 2.
 	errInvalidDifficulty = errors.New("invalid difficulty")
 	// errInvalidTimestamp is returned if the timestamp of a block is lower than
-	// the previous block's timestamp + the minimum block period.
+	// the previous block's timestamp and the minimum block period.
 	errInvalidTimestamp = errors.New("invalid timestamp")
 	errUncleDetected    = errors.New("uncles not allowed")
 )
@@ -254,7 +254,7 @@ func ValidateHeaderTime(
 		return err
 	}
 
-	// Post Bhilai HF, reject blocks form non-primary producers if they're earlier than the expected time
+	// Post Bhilai HF, reject blocks from non-primary producers if they're earlier than the expected time
 	if config.IsBhilai(header.Number.Uint64()) && succession != 0 {
 		if header.Time > uint64(now.Unix()) {
 			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
@@ -268,12 +268,13 @@ func ValidateHeaderTime(
 	return nil
 }
 
-// BorRLP returns the rlp bytes which needs to be signed for the bor
-// sealing. The RLP to sign consists of the entire header apart from the 65 byte signature
+// BorRLP returns the rlp bytes which need to be signed for the bor sealing.
+// The RLP to sign consists of the entire header apart from the 65-byte signature
 // contained at the end of the extra data.
 //
 // Note, the method requires the extra data to be at least 65 bytes, otherwise it
-// panics. This is done to avoid accidentally using both forms (signature present
+// panics.
+// This is done to avoid accidentally using both forms (signature present
 // or not), which could be abused to produce different hashes for the same header.
 func BorRLP(header *types.Header, c *borcfg.BorConfig) []byte {
 	b := new(bytes.Buffer)
@@ -308,6 +309,9 @@ type Bor struct {
 	logger         log.Logger
 	rootHashCache  *lru.ARCCache[string, string]
 	headerProgress HeaderProgress
+
+	// executed in CommitStates when rules.IsStateSync is true
+	lastStateSyncData []*types.StateSyncData
 }
 
 type signer struct {
@@ -369,7 +373,7 @@ func New(
 	return c
 }
 
-// NewRo is used by the rpcdaemon and tests which need read only access to the provided data services
+// NewRo is used by the rpc daemon and tests which need read-only access to the provided data services
 func NewRo(chainConfig *chain.Config, blockReader services.FullBlockReader, logger log.Logger) *Bor {
 	// get bor config
 	borConfig := chainConfig.Bor.(*borcfg.BorConfig)
@@ -419,12 +423,12 @@ func (c *Bor) Author(header *types.Header) (common.Address, error) {
 }
 
 // VerifyHeader checks whether a header conforms to the consensus rules.
-func (c *Bor) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error {
+func (c *Bor) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, _ bool) error {
 	return c.verifyHeader(chain, header, nil)
 }
 
-// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
-// method returns a quit channel to abort the operations and a results channel to
+// VerifyHeaders is similar to VerifyHeader but verifies a batch of headers.
+// The method returns a quit channel to abort the operations and a result channel to
 // retrieve the async verifications (the order is that of the input slice).
 func (c *Bor) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, _ []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
@@ -508,7 +512,8 @@ func ValidateHeaderExtraLength(extraBytes []byte) error {
 	return nil
 }
 
-// ValidateHeaderSprintValidators validates that the extra-data contains a validators list only in the last header of a sprint.
+// ValidateHeaderSprintValidators validates that the extra-data contains a validators'
+// list only in the last header of a sprint.
 func ValidateHeaderSprintValidators(header *types.Header, config *borcfg.BorConfig) error {
 	number := header.Number.Uint64()
 	isSprintEnd := config.IsSprintEnd(number)
@@ -668,7 +673,7 @@ func (c *Bor) verifySeal(chain ChainHeaderReader, header *types.Header, parents 
 
 // Prepare implements consensus.Engine, preparing all the consensus fields of the
 // header for running the transactions on top.
-func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, state *state.IntraBlockState) error {
+func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, _ *state.IntraBlockState) error {
 	// If the block isn't a checkpoint, cast a random vote (good enough for now)
 	header.Coinbase = common.Address{}
 	header.Nonce = types.BlockNonce{}
@@ -759,7 +764,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 
 	var succession int
 	signer := c.authorizedSigner.Load().signer
-	// if signer is not empty
+	// if the signer is not empty
 	if !bytes.Equal(signer.Bytes(), common.Address{}.Bytes()) {
 		succession, err = validatorSet.GetSignerSuccessionNumber(signer, number)
 		if err != nil {
@@ -772,9 +777,10 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	if header.Time < uint64(now.Unix()) {
 		header.Time = uint64(now.Unix())
 	} else {
-		// For primary validators, wait until the current block production window
-		// starts. This prevents bor from starting to build next block before time
-		// as we'd like to wait for new transactions. Although this change doesn't
+		// For primary validators, wait until the current block production window starts.
+		// This prevents bor from starting to build the next block before time
+		// as we'd like to wait for new transactions.
+		// Although this change doesn't
 		// need a check for hard fork as it doesn't change any consensus rules, we
 		// still keep it for safety and testing.
 		if c.config.IsBhilai(number) && succession == 0 {
@@ -786,16 +792,16 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	return nil
 }
 
-func (c *Bor) CalculateRewards(config *chain.Config, header *types.Header, uncles []*types.Header, syscall consensus.SystemCall,
+func (c *Bor) CalculateRewards(_ *chain.Config, _ *types.Header, _ []*types.Header, _ consensus.SystemCall,
 ) ([]consensus.Reward, error) {
 	return []consensus.Reward{}, nil
 }
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given.
-func (c *Bor) Finalize(config *chain.Config, header *types.Header, state *state.IntraBlockState,
-	txs types.Transactions, uncles []*types.Header, r types.Receipts, withdrawals []*types.Withdrawal,
-	chain consensus.ChainReader, syscall consensus.SystemCall, skipReceiptsEval bool, logger log.Logger,
+func (c *Bor) Finalize(_ *chain.Config, header *types.Header, state *state.IntraBlockState,
+	_ types.Transactions, _ []*types.Header, _ types.Receipts, withdrawals []*types.Withdrawal,
+	chain consensus.ChainReader, syscall consensus.SystemCall, _ bool, _ log.Logger,
 ) (types.FlatRequests, error) {
 	headerNumber := header.Number.Uint64()
 
@@ -835,6 +841,8 @@ func (c *Bor) Finalize(config *chain.Config, header *types.Header, state *state.
 		return nil, err
 	}
 
+	// PIP-55: Finalize does not append txs/receipts (that’s done in FinalizeAndAssemble)
+
 	return nil, nil
 }
 
@@ -848,7 +856,7 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state *state.Intra
 
 			for addr, account := range allocs {
 				c.logger.Trace("[bor] change contract code", "address", addr)
-				state.SetCode(addr, account.Code)
+				_ = state.SetCode(addr, account.Code)
 			}
 		}
 	}
@@ -858,9 +866,9 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state *state.Intra
 
 // FinalizeAndAssemble implements consensus.Engine, ensuring no uncles are set,
 // nor block rewards given, and returns the final block.
-func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Header, state *state.IntraBlockState,
-	txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal,
-	chain consensus.ChainReader, syscall consensus.SystemCall, call consensus.Call, logger log.Logger,
+func (c *Bor) FinalizeAndAssemble(_ *chain.Config, header *types.Header, state *state.IntraBlockState,
+	txs types.Transactions, _ []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal,
+	chain consensus.ChainReader, syscall consensus.SystemCall, _ consensus.Call, _ log.Logger,
 ) (*types.Block, types.FlatRequests, error) {
 	headerNumber := header.Number.Uint64()
 
@@ -876,7 +884,7 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
 
 		if c.blockReader != nil {
-			// Post Rio/VeBlop spans won't be committed to smart contract
+			// After Rio/VeBlop HF, spans won't be committed to smart contract
 			if !c.config.IsRio(header.Number.Uint64()) {
 				// check and commit span
 				if err := c.checkAndCommitSpan(header, syscall); err != nil {
@@ -899,13 +907,23 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 		return nil, nil, err
 	}
 
+	// PIP-55: append StateSyncTx and receipt post-fork if any events executed
+	if c.config.IsStateSync(headerNumber) {
+		if stateSyncData := c.popLastStateSyncData(); len(stateSyncData) > 0 {
+			stateSyncTx := &types.StateSyncTx{StateSyncData: stateSyncData}
+			txs = append(txs, stateSyncTx)
+			stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
+			receipts = append(receipts, stateSyncReceipt)
+		}
+	}
+
 	return types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals), nil, nil
 }
 
 func (c *Bor) Initialize(config *chain.Config, chain consensus.ChainHeaderReader, header *types.Header,
-	state *state.IntraBlockState, syscall consensus.SysCallCustom, logger log.Logger, tracer *tracing.Hooks) {
+	state *state.IntraBlockState, _ consensus.SysCallCustom, _ log.Logger, _ *tracing.Hooks) {
 	if chain != nil && chain.Config().IsBhilai(header.Number.Uint64()) {
-		misc.StoreBlockHashesEip2935(header, state, config, chain)
+		_ = misc.StoreBlockHashesEip2935(header, state, config, chain)
 	}
 }
 
@@ -920,7 +938,7 @@ func (c *Bor) Authorize(currentSigner common.Address, signFn SignerFn) {
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
 // the local signing credentials.
-func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
+func (c *Bor) Seal(_ consensus.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
 	block := blockWithReceipts.Block
 	receipts := blockWithReceipts.Receipts
 	header := block.Header()
@@ -954,15 +972,15 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.B
 	}
 
 	var delay time.Duration
-	// Sweet, the protocol permits us to sign the block, wait for our time
+	// The protocol permits us to sign the block, wait for our time
 	if c.config.IsBhilai(header.Number.Uint64()) && successionNumber == 0 {
 		// For primary producers, set the delay to `header.Time - block time` instead of `header.Time`
-		// for early block announcement instead of waiting for full block time.
+		// for the early block announcement instead of waiting for full block time.
 		delay = time.Until(time.Unix(int64(header.Time)-int64(c.config.CalculatePeriod(number)), 0))
 	} else {
 		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time
 	}
-	// wiggle was already accounted for in header.Time, this is just for logging
+	// wiggle was already accounted for in the header.Time, this is just for logging
 	wiggle := time.Duration(successionNumber) * time.Duration(c.config.CalculateBackupMultiplier(number)) * time.Second
 
 	// Sign all the things!
@@ -1056,7 +1074,7 @@ func (c *Bor) IsProposer(header *types.Header) (bool, error) {
 // CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty
 // that a new block should have based on the previous blocks in the chain and the
 // current signer.
-func (c *Bor) CalcDifficulty(chain consensus.ChainHeaderReader, _, _ uint64, _ *big.Int, parentNumber uint64, parentHash, _ common.Hash, _ uint64) *big.Int {
+func (c *Bor) CalcDifficulty(_ consensus.ChainHeaderReader, _, _ uint64, _ *big.Int, parentNumber uint64, _, _ common.Hash, _ uint64) *big.Int {
 	signer := c.authorizedSigner.Load().signer
 
 	validatorSet, err := c.spanReader.Producers(context.Background(), parentNumber+1)
@@ -1073,16 +1091,16 @@ func (c *Bor) SealHash(header *types.Header) common.Hash {
 	return SealHash(header, c.config)
 }
 
-func (c *Bor) IsServiceTransaction(sender common.Address, syscall consensus.SystemCall) bool {
+func (c *Bor) IsServiceTransaction(_ common.Address, _ consensus.SystemCall) bool {
 	return false
 }
 
-// Depricated: To get the API use jsonrpc.APIList
-func (c *Bor) APIs(chain consensus.ChainHeaderReader) []rpc.API {
+// APIs method is deprecated: To get the APIs use jsonrpc.APIList
+func (c *Bor) APIs(_ consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{}
 }
 
-// Only needed to satisfy the consensus.Engine interface
+// Close is only needed to satisfy the consensus.Engine interface
 func (c *Bor) Close() error {
 	return nil
 }
@@ -1096,8 +1114,8 @@ func (c *Bor) checkAndCommitSpan(header *types.Header, syscall consensus.SystemC
 
 	// Whenever `checkAndCommitSpan` is called for the first time, during the start of 'technically'
 	// second sprint, we need the 0th as well as the 1st span. The contract returns an empty
-	// span (i.e. all fields set to 0). Span 0 doesn't need to be committed explicitly and
-	// is committed eventually when we commit 1st span (as per the contract). The check below
+	// span (i.e., all fields set to 0). Span 0 doesn't need to be committed explicitly and
+	// is committed eventually when we commit the 1st span (as per the contract). The check below
 	// takes care of that and commits the 1st span (hence the `currentSpan.Id+1` param).
 	if currentSpan.EndBlock == 0 {
 		if err := c.fetchAndCommitSpan(uint64(currentSpan.Id+1), syscall); err != nil {
@@ -1105,7 +1123,7 @@ func (c *Bor) checkAndCommitSpan(header *types.Header, syscall consensus.SystemC
 		}
 	}
 
-	// For subsequent calls, commit the next span on the first block of the last sprint of a span
+	// For later calls, commit the next span on the first block of the span's last sprint
 	sprintLength := c.config.CalculateSprintLength(headerNumber)
 	if currentSpan.EndBlock > sprintLength && currentSpan.EndBlock-sprintLength+1 == headerNumber {
 		if err := c.fetchAndCommitSpan(uint64(currentSpan.Id+1), syscall); err != nil {
@@ -1263,12 +1281,35 @@ func (c *Bor) CommitStates(
 		}
 	}
 
+	executed := make([]*types.StateSyncData, 0, len(events))
+
 	for _, event := range events {
-		_, err := syscall(*event.To(), event.Data())
-		if err != nil {
+		if _, err := syscall(*event.To(), event.Data()); err != nil {
 			return err
 		}
+
+		var ev types.StateSyncData
+		if err := rlp.DecodeBytes(event.Data(), &ev); err != nil {
+			continue // not a state-sync event, skip
+		}
+
+		executed = append(executed, &types.StateSyncData{
+			ID:       ev.ID,
+			Contract: ev.Contract,
+			Data:     ev.Data,
+			TxHash:   ev.TxHash,
+		})
 	}
+
+	// PIP-55: if the StateSync fork is active, stash executed events
+	if c.config.IsStateSync(blockNum) {
+		if len(executed) > 0 {
+			c.lastStateSyncData = executed
+		} else {
+			c.lastStateSyncData = nil
+		}
+	}
+
 	return nil
 }
 
@@ -1312,7 +1353,7 @@ func (c *Bor) GetTransferFunc() evmtypes.TransferFunc {
 	return BorTransfer
 }
 
-// AddFeeTransferLog adds fee transfer log into state
+// AddFeeTransferLog adds fee transfer log into the state
 // Deprecating transfer log and will be removed in future fork. PLEASE DO NOT USE this transfer log going forward. Parameters won't get updated as expected going forward with EIP1559
 func AddFeeTransferLog(ibs evmtypes.IntraBlockState, sender common.Address, coinbase common.Address, result *evmtypes.ExecutionResult) {
 	output1 := result.SenderInitBalance.Clone()
@@ -1362,14 +1403,14 @@ func (c *Bor) TxDependencies(h *types.Header) [][]int {
 	return blockExtraData.TxDependencies
 }
 
-// In bor, RLP encoding of BlockExtraData will be stored in the Extra field in the header
+// BlockExtraData for bor, where RLP encoding will be stored in the Extra field of the header
 type BlockExtraData struct {
 	// Validator bytes of bor
 	ValidatorBytes []byte
 
-	// length of TxDependencies          ->   n (n = number of transactions in the block)
-	// length of TxDependencies[i]       ->   k (k = a whole number)
-	// k elements in TxDependencies[i]   ->   transaction indexes on which transaction i is dependent on
+	// length of TxDependencies -> n (n = number of transactions in the block)
+	// length of TxDependencies[i] -> k (k = a whole number)
+	// k elements in TxDependencies[i] -> transaction indexes on which transaction i is dependent on
 	TxDependencies [][]int
 }
 
@@ -1400,4 +1441,40 @@ func VerifyUncles(uncles []*types.Header) error {
 	}
 
 	return nil
+}
+
+func (c *Bor) popLastStateSyncData() []*types.StateSyncData {
+	out := c.lastStateSyncData
+	c.lastStateSyncData = nil
+	return out
+}
+
+// newStateSyncReceipt creates a new receipt for the StateSyncTx
+func newStateSyncReceipt(tx types.Transaction, prev types.Receipts, state *state.IntraBlockState, header *types.Header, txs types.Transactions) *types.Receipt {
+	// Slice logs since previous receipts
+	allLogs := state.Logs()
+	logsFromReceiptCount := countLogsFromReceipts(prev)
+	stateSyncLogs := allLogs[logsFromReceiptCount:]
+
+	r := &types.Receipt{
+		Type:              tx.Type(),
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: header.GasUsed,
+		GasUsed:           0,
+		TxHash:            tx.Hash(),
+		Logs:              stateSyncLogs,
+		BlockNumber:       header.Number,
+		TransactionIndex:  uint(len(txs) - 1),
+	}
+	r.Bloom = types.CreateBloom(types.Receipts{r})
+	return r
+}
+
+// countLogsFromReceipts counts the total number of logs in the given receipts.
+func countLogsFromReceipts(receipts types.Receipts) int {
+	count := 0
+	for _, r := range receipts {
+		count += len(r.Logs)
+	}
+	return count
 }

--- a/polygon/bor/bor_internal_test.go
+++ b/polygon/bor/bor_internal_test.go
@@ -105,7 +105,7 @@ func TestCommitStatesIndore(t *testing.T) {
 		return nil, nil
 	}
 
-	err := bor.CommitStates(header, statefull.ChainContext{Chain: cr}, syscall, true)
+	_, err := bor.CommitStates(header, statefull.ChainContext{Chain: cr}, syscall, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, called)
 }

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -25,10 +25,10 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 )
 
-// BorConfig is the consensus engine configs for Matic bor based sealing.
+// BorConfig is the consensus engine configs for bor-based sealing.
 type BorConfig struct {
 	Period                map[string]uint64 `json:"period"`                // Number of seconds between blocks to enforce
-	ProducerDelay         map[string]uint64 `json:"producerDelay"`         // Number of seconds delay between two producer interval
+	ProducerDelay         map[string]uint64 `json:"producerDelay"`         // Number of seconds-delay between two producers'
 	Sprint                map[string]uint64 `json:"sprint"`                // Epoch length to proposer
 	BackupMultiplier      map[string]uint64 `json:"backupMultiplier"`      // Backup multiplier to determine the wiggle time
 	ValidatorContract     string            `json:"validatorContract"`     // Validator set contract
@@ -37,14 +37,16 @@ type BorConfig struct {
 	OverrideStateSyncRecords map[string]int         `json:"overrideStateSyncRecords"` // override state records count
 	BlockAlloc               map[string]interface{} `json:"blockAlloc"`
 
-	JaipurBlock                *big.Int                  `json:"jaipurBlock"`                // Jaipur switch block (nil = no fork, 0 = already on Jaipur)
-	DelhiBlock                 *big.Int                  `json:"delhiBlock"`                 // Delhi switch block (nil = no fork, 0 = already on Delhi)
-	IndoreBlock                *big.Int                  `json:"indoreBlock"`                // Indore switch block (nil = no fork, 0 = already on Indore)
-	AgraBlock                  *big.Int                  `json:"agraBlock"`                  // Agra switch block (nil = no fork, 0 = already on Agra)
-	NapoliBlock                *big.Int                  `json:"napoliBlock"`                // Napoli switch block (nil = no fork, 0 = already on Napoli)
-	AhmedabadBlock             *big.Int                  `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on Ahmedabad)
-	BhilaiBlock                *big.Int                  `json:"bhilaiBlock"`                // Bhilai switch block (nil = no fork, 0 = already on Ahmedabad)
-	RioBlock                   *big.Int                  `json:"rioBlock"`                   // Rio switch block (nil = no fork, 0 = already on Rio)
+	JaipurBlock    *big.Int `json:"jaipurBlock"`    // Jaipur switch block (nil = no fork, 0 = already on Jaipur)
+	DelhiBlock     *big.Int `json:"delhiBlock"`     // Delhi switch block (nil = no fork, 0 = already on Delhi)
+	IndoreBlock    *big.Int `json:"indoreBlock"`    // Indore switch block (nil = no fork, 0 = already on Indore)
+	AgraBlock      *big.Int `json:"agraBlock"`      // Agra switch block (nil = no fork, 0 = already on Agra)
+	NapoliBlock    *big.Int `json:"napoliBlock"`    // Napoli switch block (nil = no fork, 0 = already on Napoli)
+	AhmedabadBlock *big.Int `json:"ahmedabadBlock"` // Ahmedabad switch block (nil = no fork, 0 = already on Ahmedabad)
+	BhilaiBlock    *big.Int `json:"bhilaiBlock"`    // Bhilai switch block (nil = no fork, 0 = already on Ahmedabad)
+	RioBlock       *big.Int `json:"rioBlock"`       // Rio switch block (nil = no fork, 0 = already on Rio)
+	StateSyncBlock *big.Int `json:"stateSyncBlock"` // StateSync switch block (nil = no fork, 0 = already on StateSync) // TODO define better name
+
 	StateSyncConfirmationDelay map[string]uint64         `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 	Coinbase                   map[string]common.Address `json:"coinbase"`                   // coinbase address
 	sprints                    sprints
@@ -141,9 +143,9 @@ func (c *BorConfig) IsIndore(number uint64) bool {
 	return isForked(c.IndoreBlock, number)
 }
 
-// IsAgra returns whether num is either equal to the Agra fork block or greater.
+// IsAgra returns whether the num is either equal to the Agra fork block or greater.
 // The Agra hard fork is based on the Shanghai hard fork, but it doesn't include withdrawals.
-// Also Agra is activated based on the block number rather than the timestamp.
+// Also, Agra is activated based on the block number rather than the timestamp.
 // Refer to https://forum.polygon.technology/t/pip-28-agra-hardfork
 func (c *BorConfig) IsAgra(num uint64) bool {
 	return isForked(c.AgraBlock, num)
@@ -184,6 +186,14 @@ func (c *BorConfig) IsRio(number uint64) bool {
 
 func (c *BorConfig) GetRioBlock() *big.Int {
 	return c.RioBlock
+}
+
+func (c *BorConfig) IsStateSync(number uint64) bool {
+	return isForked(c.StateSyncBlock, number)
+}
+
+func (c *BorConfig) GetStateSyncBlock() *big.Int {
+	return c.StateSyncBlock
 }
 
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {


### PR DESCRIPTION
In this PR, we implement the canonical inclusion of state-sync txs in block bodies, as per relative PIP.
This PR reflects the Erigon's changes for this PR in bor:
- https://github.com/0xPolygon/bor/pull/1726

The PR introduces a new typed system transaction, which is included to blocks that execute StateSync events. 
Such txs have zero gas/fees and does not run EVM code, but anchors all StateSync outcomes into the canonical transaction/receipt set. This results in inclusion of such txs into transactionsRoot, receiptsRoot, and logsBloom.

The changes requires a hard fork.

Test worked when enabling StateSync HF from block 0 with the following kurtosis configs
- parameters:
```
polygon_pos_package:
  participants:
    - kind: validator
      cl_type: heimdall-v2
      cl_image: 0xpolygon/heimdall-v2:0.3.1
      el_type: erigon
      el_image: 0xpolygon/erigon:v3.0.18-test
      count: 4
    - kind: rpc
      cl_type: heimdall-v2
      cl_image: 0xpolygon/heimdall-v2:0.3.1
      el_type: erigon
      el_image: 0xpolygon/erigon:v3.0.18-test
      count: 2
  additional_services:
    - test_runner
  ```
 - erigon genesis
 ```
 {
  "config": {
    ...
    },
    "bor": {
      "agraBlock": 0,
      "napoliBlock": 0,
      "jaipurBlock": 0,
      "delhiBlock": 0,
      "indoreBlock": 0,
      "ahmedabadBlock": 0,
      "bhilaiBlock": 0,
      "stateSyncBlock": 0,
      ...
}
```
Receipt was successfully received
<img width="668" height="495" alt="image" src="https://github.com/user-attachments/assets/810417aa-b4d1-4583-8e6b-58cb06392b78" />
