### PR TITLE
state-sync txs inclusion for 3.1

### DIFF
--- a/cl/cltypes/beacon_block_test.go
+++ b/cl/cltypes/beacon_block_test.go
@@ -53,7 +53,7 @@ func TestBeaconBody(t *testing.T) {
 	executionChanges := solid.NewStaticListSSZ[*SignedBLSToExecutionChange](MaxExecutionChanges, 172)
 	blobKzgCommitments := solid.NewStaticListSSZ[*KZGCommitment](MaxBlobsCommittmentsPerBlock, 48)
 	version := clparams.DenebVersion
-	block := types.NewBlock(&types.Header{
+	block, _ := types.NewBlock(&types.Header{
 		BaseFee: big.NewInt(1),
 	}, []types.Transaction{types.NewTransaction(1, [20]byte{}, uint256.NewInt(1), 5, uint256.NewInt(2), nil)}, nil, nil, types.Withdrawals{&types.Withdrawal{
 		Index: 69,

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -282,7 +282,7 @@ func Main(ctx *cli.Context) error {
 		ommerN.SetUint64(header.Number.Uint64() - ommer.Delta)
 		ommerHeaders[i] = &types.Header{Coinbase: ommer.Address, Number: &ommerN}
 	}
-	block := types.NewBlock(header, txs, ommerHeaders, nil /* receipts */, prestate.Env.Withdrawals)
+	block, _ := types.NewBlock(header, txs, ommerHeaders, nil /* receipts */, prestate.Env.Withdrawals)
 
 	getHash := func(num uint64) (common.Hash, error) {
 		if prestate.Env.BlockHashes == nil {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -1137,7 +1137,7 @@ func (e *remoteConsensusEngine) Finalize(_ *chain.Config, _ *types.Header, _ *st
 	panic("remoteConsensusEngine.Finalize not supported")
 }
 
-func (e *remoteConsensusEngine) FinalizeAndAssemble(_ *chain.Config, _ *types.Header, _ *state.IntraBlockState, _ types.Transactions, _ []*types.Header, _ types.Receipts, _ []*types.Withdrawal, _ consensus.ChainReader, _ consensus.SystemCall, _ consensus.Call, _ log.Logger) (*types.Block, types.FlatRequests, error) {
+func (e *remoteConsensusEngine) FinalizeAndAssemble(_ *chain.Config, _ *types.Header, _ *state.IntraBlockState, _ types.Transactions, _ []*types.Header, _ types.Receipts, _ []*types.Withdrawal, _ consensus.ChainReader, _ consensus.SystemCall, _ consensus.Call, _ log.Logger) (*types.Block, types.Receipts, types.FlatRequests, error) {
 	panic("remoteConsensusEngine.FinalizeAndAssemble not supported")
 }
 

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -22,13 +22,14 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"github.com/erigontech/erigon-lib/common/dir"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
+
+	"github.com/erigontech/erigon-lib/common/dir"
 
 	"github.com/holiman/uint256"
 	"github.com/spf13/cobra"
@@ -754,7 +755,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	if !vmConfig.ReadOnly {
 		// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 		tx := block.Transactions()
-		if _, _, err := engine.FinalizeAndAssemble(chainConfig, header, ibs, tx, block.Uncles(), receipts, block.Withdrawals(), nil, nil, nil, logger); err != nil {
+		if _, _, _, err := engine.FinalizeAndAssemble(chainConfig, header, ibs, tx, block.Uncles(), receipts, block.Withdrawals(), nil, nil, nil, logger); err != nil {
 			return nil, fmt.Errorf("finalize of block %d failed: %w", block.NumberU64(), err)
 		}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -346,14 +346,14 @@ func SysCreate(contract common.Address, data []byte, chainConfig *chain.Config, 
 }
 
 func FinalizeBlockExecution(
-	engine consensus.Engine, stateReader state.StateReader,
+	engine consensus.Engine, _ state.StateReader,
 	header *types.Header, txs types.Transactions, uncles []*types.Header,
 	stateWriter state.StateWriter, cc *chain.Config,
 	ibs *state.IntraBlockState, receipts types.Receipts,
 	withdrawals []*types.Withdrawal, chainReader consensus.ChainReader,
 	isMining bool,
 	logger log.Logger,
-	tracer *tracing.Hooks,
+	_ *tracing.Hooks,
 ) (newBlock *types.Block, retRequests types.FlatRequests, err error) {
 	syscall := func(contract common.Address, data []byte) ([]byte, error) {
 		ret, err := SysCallContract(contract, data, cc, ibs, header, engine, false /* constCall */, vm.Config{})
@@ -361,7 +361,7 @@ func FinalizeBlockExecution(
 	}
 
 	if isMining {
-		newBlock, retRequests, err = engine.FinalizeAndAssemble(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, nil, logger)
+		newBlock, receipts, retRequests, err = engine.FinalizeAndAssemble(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, nil, logger)
 	} else {
 		retRequests, err = engine.Finalize(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, false, logger)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -361,7 +361,8 @@ func FinalizeBlockExecution(
 	}
 
 	if isMining {
-		newBlock, receipts, retRequests, err = engine.FinalizeAndAssemble(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, nil, logger)
+
+		newBlock, _, retRequests, err = engine.FinalizeAndAssemble(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, nil, logger)
 	} else {
 		retRequests, err = engine.Finalize(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, false, logger)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -371,7 +371,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 		txNumIncrement()
 		if b.engine != nil {
 			// Finalize and seal the block
-			if _, _, err := b.engine.FinalizeAndAssemble(config, b.header, ibs, b.txs, b.uncles, b.receipts, nil, nil, nil, nil, logger); err != nil {
+			if _, _, _, err := b.engine.FinalizeAndAssemble(config, b.header, ibs, b.txs, b.uncles, b.receipts, nil, nil, nil, nil, logger); err != nil {
 				return nil, nil, fmt.Errorf("call to FinaliseAndAssemble: %w", err)
 			}
 			// Write state changes to db
@@ -395,8 +395,8 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 			b.header.Root = common.BytesToHash(stateRoot)
 
 			// Recreating block to make sure Root makes it into the header
-			block := types.NewBlockForAsembling(b.header, b.txs, b.uncles, b.receipts, nil /* withdrawals */)
-			return block, b.receipts, nil
+			block, recs := types.NewBlockForAsembling(b.header, b.txs, b.uncles, b.receipts, nil /* withdrawals */)
+			return block, recs, nil
 		}
 		return nil, nil, errors.New("no engine to generate blocks")
 	}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -74,13 +74,13 @@ func TestGenesisBlockRoots(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	block, _, err := core.GenesisToBlock(chainspec.MainnetGenesisBlock(), datadir.New(t.TempDir()), log.Root())
+	block, _, _, err := core.GenesisToBlock(chainspec.MainnetGenesisBlock(), datadir.New(t.TempDir()), log.Root())
 	require.NoError(err)
 	if block.Hash() != chainspec.MainnetGenesisHash {
 		t.Errorf("wrong mainnet genesis hash, got %v, want %v", block.Hash(), chainspec.MainnetGenesisHash)
 	}
 
-	block, _, err = core.GenesisToBlock(chainspec.GnosisGenesisBlock(), datadir.New(t.TempDir()), log.Root())
+	block, _, _, err = core.GenesisToBlock(chainspec.GnosisGenesisBlock(), datadir.New(t.TempDir()), log.Root())
 	require.NoError(err)
 	if block.Root() != chainspec.GnosisGenesisStateRoot {
 		t.Errorf("wrong Gnosis Chain genesis state root, got %v, want %v", block.Root(), chainspec.GnosisGenesisStateRoot)
@@ -89,7 +89,7 @@ func TestGenesisBlockRoots(t *testing.T) {
 		t.Errorf("wrong Gnosis Chain genesis hash, got %v, want %v", block.Hash(), chainspec.GnosisGenesisHash)
 	}
 
-	block, _, err = core.GenesisToBlock(chainspec.ChiadoGenesisBlock(), datadir.New(t.TempDir()), log.Root())
+	block, _, _, err = core.GenesisToBlock(chainspec.ChiadoGenesisBlock(), datadir.New(t.TempDir()), log.Root())
 	require.NoError(err)
 	if block.Root() != chainspec.ChiadoGenesisStateRoot {
 		t.Errorf("wrong Chiado genesis state root, got %v, want %v", block.Root(), chainspec.ChiadoGenesisStateRoot)
@@ -98,7 +98,7 @@ func TestGenesisBlockRoots(t *testing.T) {
 		t.Errorf("wrong Chiado genesis hash, got %v, want %v", block.Hash(), chainspec.ChiadoGenesisHash)
 	}
 
-	block, _, err = core.GenesisToBlock(chainspec.TestGenesisBlock(), datadir.New(t.TempDir()), log.Root())
+	block, _, _, err = core.GenesisToBlock(chainspec.TestGenesisBlock(), datadir.New(t.TempDir()), log.Root())
 	require.NoError(err)
 	if block.Root() != chainspec.TestGenesisStateRoot {
 		t.Errorf("wrong test genesis state root, got %v, want %v", block.Root(), chainspec.TestGenesisStateRoot)

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -156,7 +156,7 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideOsakaTime *bi
 
 	// Check whether the genesis block is already written.
 	if genesis != nil {
-		block, _, err1 := GenesisToBlock(genesis, dirs, logger)
+		block, _, _, err1 := GenesisToBlock(genesis, dirs, logger)
 		if err1 != nil {
 			return genesis.Config, nil, err1
 		}
@@ -213,8 +213,8 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideOsakaTime *bi
 	return newCfg, storedBlock, nil
 }
 
-func WriteGenesisState(g *types.Genesis, tx kv.RwTx, dirs datadir.Dirs, logger log.Logger) (*types.Block, *state.IntraBlockState, error) {
-	block, statedb, err := GenesisToBlock(g, dirs, logger)
+func WriteGenesisState(g *types.Genesis, _ kv.RwTx, dirs datadir.Dirs, logger log.Logger) (*types.Block, *state.IntraBlockState, error) {
+	block, _, statedb, err := GenesisToBlock(g, dirs, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -319,7 +319,7 @@ var DevnetSignKey = func(address common.Address) *ecdsa.PrivateKey {
 
 // GenesisToBlock creates the genesis block and writes state of a genesis specification
 // to the given database (or discards it if nil).
-func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*types.Block, *state.IntraBlockState, error) {
+func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*types.Block, types.Receipts, *state.IntraBlockState, error) {
 	if dirs.SnapDomain == "" {
 		panic("empty `dirs` variable")
 	}
@@ -431,12 +431,14 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 	})
 
 	if err := wg.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	head.Root = root
 
-	return types.NewBlock(head, nil, nil, nil, withdrawals), statedb, nil
+	block, recs := types.NewBlock(head, nil, nil, nil, withdrawals)
+
+	return block, recs, statedb, nil
 }
 
 // GenesisWithoutStateToBlock creates the genesis block, assuming an empty state.

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -178,6 +178,8 @@ type BorConfig interface {
 	GetAhmedabadBlock() *big.Int
 	IsBhilai(num uint64) bool
 	GetBhilaiBlock() *big.Int
+	IsStateSync(num uint64) bool
+	GetStateSyncBlock() *big.Int
 	StateReceiverContractAddress() common.Address
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
@@ -195,12 +197,13 @@ func (c *Config) String() string {
 	engine := c.getEngine()
 
 	if c.Bor != nil {
-		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, StateSync: %v, Engine: %v}",
 			c.ChainID,
 			c.Bor.GetAgraBlock(),
 			c.Bor.GetNapoliBlock(),
 			c.Bor.GetAhmedabadBlock(),
 			c.Bor.GetBhilaiBlock(),
+			c.Bor.GetStateSyncBlock(),
 			engine,
 		)
 	}
@@ -668,6 +671,7 @@ type Rules struct {
 	IsCancun, IsNapoli, IsBhilai                      bool
 	IsPrague, IsOsaka                                 bool
 	IsAura                                            bool
+	IsStateSync                                       bool // TODO define a name when we have a fork that enables it
 }
 
 // Rules ensures c's ChainID is not nil and returns a new Rules instance

--- a/erigon-lib/types/block.go
+++ b/erigon-lib/types/block.go
@@ -1003,7 +1003,7 @@ func (bb *Body) DecodeRLP(s *rlp.Stream) error {
 // The values of TxHash, UncleHash, ReceiptHash, Bloom, and WithdrawalHash
 // in the header are ignored and set to the values derived from
 // the given txs, uncles, receipts, and withdrawals.
-func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*Receipt, withdrawals []*Withdrawal) *Block {
+func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*Receipt, withdrawals []*Withdrawal) (*Block, Receipts) {
 	b := &Block{header: CopyHeader(header)}
 
 	// TODO: panic if len(txs) != len(receipts)
@@ -1050,14 +1050,14 @@ func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*R
 
 	b.header.ParentBeaconBlockRoot = header.ParentBeaconBlockRoot
 	b.header.mutable = false //Force immutability of block and header. Use `NewBlockForAsembling` if you need mutable block
-	return b
+	return b, receipts
 }
 
 // NewBlockForAsembling - creating new block - which allow mutation of fileds. Use it for block-assembly
-func NewBlockForAsembling(header *Header, txs []Transaction, uncles []*Header, receipts []*Receipt, withdrawals []*Withdrawal) *Block {
-	b := NewBlock(header, txs, uncles, receipts, withdrawals)
+func NewBlockForAsembling(header *Header, txs []Transaction, uncles []*Header, receipts []*Receipt, withdrawals []*Withdrawal) (*Block, Receipts) {
+	b, receipts := NewBlock(header, txs, uncles, receipts, withdrawals)
 	b.header.mutable = true
-	return b
+	return b, receipts
 }
 
 // NewBlockFromStorage like NewBlock but used to create Block object when read it from DB

--- a/erigon-lib/types/block_test.go
+++ b/erigon-lib/types/block_test.go
@@ -361,7 +361,8 @@ func makeBenchBlock() *Block {
 			Extra:      []byte("benchmark uncle"),
 		}
 	}
-	return NewBlock(header, txs, uncles, receipts, nil /* withdrawals */)
+	block, _ := NewBlock(header, txs, uncles, receipts, nil /* withdrawals */)
+	return block
 }
 
 func TestCanEncodeAndDecodeRawBody(t *testing.T) {
@@ -510,7 +511,7 @@ func TestWithdrawalsEncoding(t *testing.T) {
 		Amount:    5_000_000_000,
 	}
 
-	block := NewBlock(&header, nil, nil, nil, withdrawals)
+	block, _ := NewBlock(&header, nil, nil, nil, withdrawals)
 	_ = block.Size()
 
 	encoded, err := rlp.EncodeToBytes(block)
@@ -522,7 +523,7 @@ func TestWithdrawalsEncoding(t *testing.T) {
 	assert.Equal(t, block.Hash(), decoded.Hash())
 
 	// Now test with empty withdrawals
-	block2 := NewBlock(&header, nil, nil, nil, []*Withdrawal{})
+	block2, _ := NewBlock(&header, nil, nil, nil, []*Withdrawal{})
 	_ = block2.Size()
 
 	encoded2, err := rlp.EncodeToBytes(block2)

--- a/erigon-lib/types/state_data.go
+++ b/erigon-lib/types/state_data.go
@@ -18,10 +18,10 @@ package types
 
 import "github.com/erigontech/erigon-lib/common"
 
-// StateSyncData represents state received from Ethereum Blockchain
+// StateSyncData represents state received from Ethereum Blockchain and stored in L2 via the StateSync mechanism.
 type StateSyncData struct {
 	ID       uint64
 	Contract common.Address
-	Data     string
-	TxHash   common.Hash
+	Data     []byte
+	TxHash   common.Hash // L1 TxHash
 }

--- a/erigon-lib/types/state_sync_tx.go
+++ b/erigon-lib/types/state_sync_tx.go
@@ -1,0 +1,288 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/big"
+
+	"github.com/erigontech/erigon-lib/chain"
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/crypto"
+	"github.com/erigontech/erigon-lib/rlp"
+
+	"github.com/holiman/uint256"
+)
+
+// StateSyncTx is the system transaction of Bor to introduce fetched state sync events from Heimdall
+type StateSyncTx struct {
+	StateSyncData []*StateSyncData
+}
+
+func (tx *StateSyncTx) GetPrice() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetTip() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetGas() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) Type() byte {
+	return StateSyncTxType
+}
+
+func (tx *StateSyncTx) GetChainID() *uint256.Int {
+	panic("chainID called from StateSyncTx")
+}
+
+func (tx *StateSyncTx) GetNonce() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) GetTipCap() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetEffectiveGasTip(_ *uint256.Int) *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetFeeCap() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetBlobHashes() []common.Hash {
+	return nil
+}
+
+func (tx *StateSyncTx) GetGasLimit() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) GetBlobGas() uint64 {
+	return 0
+}
+
+func (tx *StateSyncTx) GetValue() *uint256.Int {
+	return uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) GetTo() *common.Address {
+	return &common.Address{}
+}
+
+func (tx *StateSyncTx) AsMessage(_ Signer, baseFee *big.Int, rules *chain.Rules) (*Message, error) {
+	if !rules.IsStateSync {
+		// TODO change to better name when we have a hard fork for this
+		return nil, errors.New("StateSync typed tx requires StateSync hard fork")
+	}
+	msg := Message{
+		nonce:      0,
+		gasLimit:   0,
+		gasPrice:   *uint256.NewInt(0),
+		tipCap:     *uint256.NewInt(0),
+		feeCap:     *uint256.NewInt(0),
+		to:         tx.GetTo(),
+		amount:     *uint256.NewInt(0),
+		data:       []byte{},
+		accessList: nil,
+		checkNonce: false,
+	}
+	if baseFee != nil {
+		_ = msg.gasPrice.SetFromBig(baseFee)
+	}
+
+	msg.from = common.Address{}
+	return &msg, nil
+}
+
+func (tx *StateSyncTx) WithSignature(_ Signer, _ []byte) (Transaction, error) {
+	return nil, errors.New("StateSyncTx are not signed")
+}
+
+func (tx *StateSyncTx) Hash() common.Hash {
+	// Serialize inner payload ([]StateSyncData)
+	var buf bytes.Buffer
+	// first write the type prefix
+	buf.WriteByte(StateSyncTxType)
+	// Then RLP-encode the slice
+	if err := tx.encode(&buf); err != nil {
+		panic("StateSyncTx encode failed: " + err.Error())
+	}
+	return crypto.Keccak256Hash(buf.Bytes())
+}
+
+func (tx *StateSyncTx) SigningHash(_ *big.Int) common.Hash {
+	// StateSync txs are never signed, return canonical hash
+	return tx.Hash()
+}
+
+func (tx *StateSyncTx) GetData() []byte {
+	return []byte{}
+}
+
+func (tx *StateSyncTx) GetAccessList() AccessList {
+	return nil
+}
+
+func (tx *StateSyncTx) GetAuthorizations() []Authorization {
+	return nil
+}
+
+func (tx *StateSyncTx) Protected() bool {
+	return true
+}
+
+func (tx *StateSyncTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int) {
+	return uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0)
+}
+
+func (tx *StateSyncTx) EncodingSize() int {
+	var b bytes.Buffer
+	_ = tx.encode(&b)
+	return 1 + b.Len()
+}
+
+// EncodeRLP writes the inner payload ([]StateSyncData) without the type prefix.
+func (tx *StateSyncTx) EncodeRLP(w io.Writer) error {
+	if tx == nil {
+		return errors.New("nil StateSyncTx")
+	}
+	var buf bytes.Buffer
+	if err := tx.encode(&buf); err != nil {
+		return err
+	}
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// DecodeRLP consumes the RLP stream and populates tx.StateSyncData.
+// The type byte (0x7F) is already stripped by the UnmarshalTransaction path.
+func (tx *StateSyncTx) DecodeRLP(s *rlp.Stream) error {
+	raw, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	return tx.decode(raw)
+}
+
+func (tx *StateSyncTx) MarshalBinary(w io.Writer) error {
+	if _, err := w.Write([]byte{StateSyncTxType}); err != nil {
+		return err
+	}
+	return tx.EncodeRLP(w)
+}
+
+func (tx *StateSyncTx) Sender(_ Signer) (common.Address, error) {
+	return common.Address{}, nil
+}
+
+func (tx *StateSyncTx) cachedSender() (common.Address, bool) {
+	return common.Address{}, false
+}
+
+func (tx *StateSyncTx) GetSender() (common.Address, bool) {
+	return common.Address{}, false
+}
+
+func (tx *StateSyncTx) SetSender(_ common.Address) {
+	// no-op, StateSyncTx has no sender
+}
+
+func (tx *StateSyncTx) IsContractDeploy() bool {
+	return false
+}
+
+func (tx *StateSyncTx) Unwrap() Transaction {
+	return tx
+}
+
+func (tx *StateSyncTx) copy() StateSyncTx {
+	if tx == nil {
+		return StateSyncTx{}
+	}
+	out := &StateSyncTx{}
+	if tx.StateSyncData != nil {
+		out.StateSyncData = make([]*StateSyncData, len(tx.StateSyncData))
+		for i, d := range tx.StateSyncData {
+			if d != nil {
+				c := *d
+				out.StateSyncData[i] = &c
+			} else {
+				out.StateSyncData[i] = nil
+			}
+		}
+	}
+	return *out
+}
+
+// accessors for innerTx.
+
+func (tx *StateSyncTx) effectiveGasPrice(_ *big.Int, _ *big.Int) *big.Int {
+	return big.NewInt(0)
+}
+
+func (tx *StateSyncTx) rawSignatureValues() (v, r, s *big.Int) {
+	panic("no signatures on StateSyncTx")
+}
+
+func (tx *StateSyncTx) setSignatureValues(_, _, _, _ *big.Int) {
+	panic("no sigs on StateSyncTx")
+}
+
+func (tx *StateSyncTx) encode(buf *bytes.Buffer) error {
+	if tx == nil {
+		return errors.New("nil StateSyncTx")
+	}
+	// Validate ascending and contiguous IDs as per PIP-74
+	var prev uint64
+	for i, d := range tx.StateSyncData {
+		if d == nil {
+			return errors.New("nil StateSyncData")
+		}
+		if i == 0 {
+			prev = d.ID
+		} else {
+			if d.ID != prev+1 {
+				return errors.New("stateSyncData IDs must be ascending and contiguous")
+			}
+			prev = d.ID
+		}
+	}
+	enc := make([]StateSyncData, 0, len(tx.StateSyncData))
+	for _, d := range tx.StateSyncData {
+		enc = append(enc, *d)
+	}
+	return rlp.Encode(buf, enc)
+}
+
+func (tx *StateSyncTx) decode(b []byte) error {
+	var dec []StateSyncData
+	if err := rlp.DecodeBytes(b, &dec); err != nil {
+		return err
+	}
+	// Validate ascending and contiguous IDs as per PIP-74
+	if len(dec) > 0 {
+		prev := dec[0].ID
+		for i := 1; i < len(dec); i++ {
+			if dec[i].ID != prev+1 {
+				return errors.New("stateSyncData IDs must be ascending and contiguous")
+			}
+			prev = dec[i].ID
+		}
+	}
+	tx.StateSyncData = make([]*StateSyncData, len(dec))
+	for i := range dec {
+		d := dec[i]
+		tx.StateSyncData[i] = &d
+	}
+	return nil
+}
+
+func (tx *StateSyncTx) sigHash(_ *big.Int) common.Hash {
+	panic("StateSyncTx has no sigHash")
+}

--- a/erigon-lib/types/state_sync_tx.go
+++ b/erigon-lib/types/state_sync_tx.go
@@ -201,6 +201,7 @@ func (tx *StateSyncTx) Unwrap() Transaction {
 	return tx
 }
 
+//nolint:unused
 func (tx *StateSyncTx) copy() StateSyncTx {
 	if tx == nil {
 		return StateSyncTx{}
@@ -222,14 +223,17 @@ func (tx *StateSyncTx) copy() StateSyncTx {
 
 // accessors for innerTx.
 
+//nolint:unused
 func (tx *StateSyncTx) effectiveGasPrice(_ *big.Int, _ *big.Int) *big.Int {
 	return big.NewInt(0)
 }
 
+//nolint:unused
 func (tx *StateSyncTx) rawSignatureValues() (v, r, s *big.Int) {
 	panic("no signatures on StateSyncTx")
 }
 
+//nolint:unused
 func (tx *StateSyncTx) setSignatureValues(_, _, _, _ *big.Int) {
 	panic("no sigs on StateSyncTx")
 }
@@ -283,6 +287,7 @@ func (tx *StateSyncTx) decode(b []byte) error {
 	return nil
 }
 
+//nolint:unused
 func (tx *StateSyncTx) sigHash(_ *big.Int) common.Hash {
 	panic("StateSyncTx has no sigHash")
 }

--- a/erigon-lib/types/transaction.go
+++ b/erigon-lib/types/transaction.go
@@ -54,6 +54,7 @@ const (
 	BlobTxType
 	SetCodeTxType
 	AccountAbstractionTxType
+	StateSyncTxType = 127
 )
 
 // Transaction is an Ethereum transaction.
@@ -179,7 +180,7 @@ func DecodeTransaction(data []byte) (Transaction, error) {
 	return tx, nil
 }
 
-// Parse transaction without envelope.
+// UnmarshalTransactionFromBinary parses the transaction without the envelope.
 func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs bool) (Transaction, error) {
 	if len(data) <= 1 {
 		return nil, fmt.Errorf("short input: %v", len(data))
@@ -202,6 +203,8 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 		t = &SetCodeTransaction{}
 	case AccountAbstractionTxType:
 		t = &AccountAbstractionTransaction{}
+	case StateSyncTxType:
+		t = &StateSyncTx{}
 	default:
 		if data[0] >= 0x80 {
 			// txn is type legacy which is RLP encoded
@@ -218,8 +221,8 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 	return t, nil
 }
 
-// Removes everything but the payload body from blob tx and prepends 0x3 at the beginning - no copy
-// Doesn't change non-blob tx
+// UnwrapTxPlayloadRlp removes everything but the payload body from blob tx and prepends 0x3 at the beginning - no copy
+// It doesn't change non-blob tx
 func UnwrapTxPlayloadRlp(blobTxRlp []byte) ([]byte, error) {
 	if blobTxRlp[0] != BlobTxType {
 		return blobTxRlp, nil

--- a/erigon-lib/types/transaction_marshalling.go
+++ b/erigon-lib/types/transaction_marshalling.go
@@ -62,6 +62,9 @@ type txJSON struct {
 	Commitments BlobKzgs  `json:"commitments,omitempty"`
 	Proofs      KZGProofs `json:"proofs,omitempty"`
 
+	// StateSync transaction fields:
+	StateSyncData *[]*StateSyncData `json:"stateSyncData,omitempty"`
+
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
 }
@@ -209,6 +212,34 @@ func (tx *BlobTxWrapper) MarshalJSON() ([]byte, error) {
 	return json.Marshal(enc)
 }
 
+// MarshalJSON for StateSyncTx serializes it as a zero-valued, unsigned system transaction.
+// This ensures eth_getBlockBy* returns it in the transaction list.
+func (tx *StateSyncTx) MarshalJSON() ([]byte, error) {
+	var enc txJSON
+	enc.Hash = tx.Hash()
+	enc.Type = hexutil.Uint64(tx.Type())
+
+	zero := hexutil.Uint64(0)
+	zeroBig := (*hexutil.Big)(big.NewInt(0))
+
+	enc.Nonce = &zero
+	enc.Gas = &zero
+	enc.GasPrice = zeroBig
+	enc.MaxFeePerBlobGas = zeroBig
+	enc.Value = zeroBig
+	empty := hexutil.Bytes{}
+	enc.Data = &empty
+	zeroAddr := common.Address{}
+	enc.To = &zeroAddr
+
+	// include state sync payload
+	if len(tx.StateSyncData) > 0 {
+		enc.StateSyncData = &tx.StateSyncData
+	}
+
+	return json.Marshal(&enc)
+}
+
 func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 	var p fastjson.Parser
 	v, err := p.ParseBytes(input)
@@ -250,6 +281,12 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 		return tx, nil
 	case SetCodeTxType:
 		tx := &SetCodeTransaction{}
+		if err = tx.UnmarshalJSON(input); err != nil {
+			return nil, err
+		}
+		return tx, nil
+	case StateSyncTxType:
+		tx := &StateSyncTx{}
 		if err = tx.UnmarshalJSON(input); err != nil {
 			return nil, err
 		}
@@ -623,4 +660,26 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 		return nil, err
 	}
 	return &btx, nil
+}
+
+// UnmarshalJSON for StateSyncTx decodes from the generic txJSON wrapper.
+// Unlike user-submitted txs, StateSyncTx has no nonce/gas/value/signature.
+// We only restore StateSyncData if present.
+func (tx *StateSyncTx) UnmarshalJSON(input []byte) error {
+	var dec txJSON
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if byte(dec.Type) != StateSyncTxType {
+		return fmt.Errorf("invalid type for StateSyncTx: %v", dec.Type)
+	}
+
+	// Parse the StateSyncData if present in JSON
+	if dec.StateSyncData != nil {
+		tx.StateSyncData = *dec.StateSyncData
+	} else {
+		tx.StateSyncData = nil
+	}
+
+	return nil
 }

--- a/erigon-lib/types/transaction_test.go
+++ b/erigon-lib/types/transaction_test.go
@@ -815,3 +815,266 @@ func TestTrailingBytes(t *testing.T) {
 		panic("Malicious transaction has not errored!") // @audit this panic is occurs
 	}
 }
+
+func TestStateSyncTx_HashAndSigningHash(t *testing.T) {
+	t.Parallel()
+	ss := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 1, Contract: testAddr, Data: []byte("foo"), TxHash: randHash()},
+			{ID: 2, Contract: testAddr, Data: []byte("bar"), TxHash: randHash()},
+		},
+	}
+	h1 := ss.Hash()
+	h2 := ss.SigningHash(nil)
+
+	if h1 != h2 {
+		t.Fatalf("expected SigningHash == Hash, got %x vs %x", h1, h2)
+	}
+	if (h1 == common.Hash{}) {
+		t.Fatal("hash must not be empty")
+	}
+}
+
+func TestStateSyncTx_RLPRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 10, Contract: testAddr, Data: []byte("payload"), TxHash: randHash()},
+			{ID: 11, Contract: testAddr, Data: []byte("payload2"), TxHash: randHash()},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := orig.MarshalBinary(&buf); err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	decoded, err := DecodeTransaction(buf.Bytes())
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	ss2, ok := decoded.(*StateSyncTx)
+	if !ok {
+		t.Fatalf("decoded wrong type: %T", decoded)
+	}
+
+	// hashes must match
+	if orig.Hash() != ss2.Hash() {
+		t.Fatalf("hash mismatch, orig %x, got %x", orig.Hash(), ss2.Hash())
+	}
+	// data length must match
+	if len(ss2.StateSyncData) != len(orig.StateSyncData) {
+		t.Fatalf("state sync data mismatch, want %d, got %d", len(orig.StateSyncData), len(ss2.StateSyncData))
+	}
+}
+
+func TestStateSyncTx_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 42, Contract: testAddr, Data: []byte("baz"), TxHash: randHash()},
+		},
+	}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("json marshal failed: %v", err)
+	}
+	tx2, err := UnmarshalTransactionFromJSON(data)
+	if err != nil {
+		t.Fatalf("json unmarshal failed: %v", err)
+	}
+	ss2, ok := tx2.(*StateSyncTx)
+	if !ok {
+		t.Fatalf("decoded wrong type: %T", tx2)
+	}
+	if ss2.Hash() != orig.Hash() {
+		t.Fatalf("hash mismatch after JSON round-trip")
+	}
+	if len(ss2.StateSyncData) != 1 || ss2.StateSyncData[0].ID != 42 {
+		t.Fatalf("unexpected state sync data after JSON round-trip: %+v", ss2.StateSyncData)
+	}
+}
+
+func TestStateSyncTx_InvalidIDs(t *testing.T) {
+	t.Parallel()
+	ss := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 5, Contract: testAddr, Data: []byte("a"), TxHash: randHash()},
+			{ID: 7, Contract: testAddr, Data: []byte("b"), TxHash: randHash()}, // gap, 6 is missing
+		},
+	}
+	var buf bytes.Buffer
+	err := ss.encode(&buf)
+	if err == nil {
+		t.Fatal("expected error due to non-contiguous IDs, got nil")
+	}
+}
+
+func TestStateSyncTx_HashSensitivity(t *testing.T) {
+	base := makeBaseStateSyncTx()
+
+	hashOf := func(mutate func(*StateSyncTx)) common.Hash {
+		// deep copy
+		st := &StateSyncTx{StateSyncData: make([]*StateSyncData, len(base.StateSyncData))}
+		for i, e := range base.StateSyncData {
+			if e != nil {
+				c := *e
+				st.StateSyncData[i] = &c
+			}
+		}
+		if mutate != nil {
+			mutate(st)
+		}
+		return st.Hash()
+	}
+
+	baseHash := hashOf(nil)
+
+	if got := hashOf(nil); got != baseHash {
+		t.Fatalf("determinism failed: %x vs %x", baseHash, got)
+	}
+
+	// Only mutations that respect contiguous IDs
+	cases := []struct {
+		name   string
+		mutate func(*StateSyncTx)
+	}{
+		{"change Contract", func(st *StateSyncTx) {
+			st.StateSyncData[0].Contract = common.HexToAddress("0x000000000000000000000000000000000000CAFE")
+		}},
+		{"change Data", func(st *StateSyncTx) {
+			st.StateSyncData[0].Data = []byte("alpha-mutated")
+		}},
+		{"change TxHash", func(st *StateSyncTx) {
+			st.StateSyncData[0].TxHash = common.HexToHash("0xAAAA")
+		}},
+		{"mutate second entry", func(st *StateSyncTx) {
+			st.StateSyncData[1].Contract = common.HexToAddress("0x000000000000000000000000000000000000BEEF")
+			st.StateSyncData[1].Data = []byte("beta-mutated")
+			st.StateSyncData[1].TxHash = common.HexToHash("0xBBBB")
+		}},
+		{"append new entry contiguous ID", func(st *StateSyncTx) {
+			st.StateSyncData = append(st.StateSyncData, &StateSyncData{
+				ID:       3, // contiguous after 1,2
+				Contract: common.HexToAddress("0x0000000000000000000000000000000000001003"),
+				Data:     []byte("gamma"),
+				TxHash:   common.HexToHash("0x3333"),
+			})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hashOf(tc.mutate); got == baseHash {
+				t.Fatalf("%s: hash did not change (base=%x, got=%x)", tc.name, baseHash, got)
+			}
+		})
+	}
+}
+
+func TestStateSyncTx_EncodeDecode_RoundTrip(t *testing.T) {
+	orig := makeBaseStateSyncTx()
+
+	var buf bytes.Buffer
+	if err := orig.encode(&buf); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	enc := buf.Bytes()
+
+	var rt StateSyncTx
+	if err := rt.decode(enc); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(orig, &rt) {
+		t.Fatalf("round-trip mismatch:\n  orig=%#v\n  rt=%#v", orig, &rt)
+	}
+
+	var buf2 bytes.Buffer
+	if err := rt.encode(&buf2); err != nil {
+		t.Fatalf("re-encode failed: %v", err)
+	}
+	if !bytes.Equal(enc, buf2.Bytes()) {
+		t.Fatalf("encode not deterministic: first=%x second=%x", enc, buf2.Bytes())
+	}
+}
+
+func TestStateSyncTx_Encode_FailsOnNilEntry(t *testing.T) {
+	withNil := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{ID: 1, Contract: testAddr, Data: []byte("alpha"), TxHash: randHash()},
+			nil, // encoder should reject this
+			{ID: 2, Contract: testAddr, Data: []byte("beta"), TxHash: randHash()},
+		},
+	}
+	var buf bytes.Buffer
+	err := withNil.encode(&buf)
+	if err == nil {
+		t.Fatalf("expected encode to fail on nil entry, got no error")
+	}
+}
+
+func TestStateSyncTx_EncodeDecode_Empty(t *testing.T) {
+	var empty StateSyncTx
+	var buf bytes.Buffer
+
+	if err := empty.encode(&buf); err != nil {
+		t.Fatalf("encode(empty) failed: %v", err)
+	}
+	var rt StateSyncTx
+	if err := rt.decode(buf.Bytes()); err != nil {
+		t.Fatalf("decode(empty) failed: %v", err)
+	}
+	if rt.StateSyncData == nil || len(rt.StateSyncData) != 0 {
+		t.Fatalf("expected empty slice, got %#v", rt.StateSyncData)
+	}
+}
+
+func TestStateSyncTx_Decode_Garbage(t *testing.T) {
+	var rt StateSyncTx
+	if err := rt.decode([]byte{0x01, 0x02, 0x03}); err == nil {
+		t.Fatalf("expected error on garbage decode")
+	}
+}
+
+func TestStateSyncTx_Encode_DeterministicAcrossCopies(t *testing.T) {
+	orig := makeBaseStateSyncTx()
+
+	// manual deep copy
+	clone := &StateSyncTx{StateSyncData: make([]*StateSyncData, len(orig.StateSyncData))}
+	for i, e := range orig.StateSyncData {
+		if e != nil {
+			c := *e
+			clone.StateSyncData[i] = &c
+		}
+	}
+
+	var b1, b2 bytes.Buffer
+	if err := orig.encode(&b1); err != nil {
+		t.Fatalf("encode(orig) failed: %v", err)
+	}
+	if err := clone.encode(&b2); err != nil {
+		t.Fatalf("encode(clone) failed: %v", err)
+	}
+	if !bytes.Equal(b1.Bytes(), b2.Bytes()) {
+		t.Fatalf("encode not deterministic across copies: enc1=%x enc2=%x", b1.Bytes(), b2.Bytes())
+	}
+}
+
+func makeBaseStateSyncTx() *StateSyncTx {
+	return &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{
+				ID:       1,
+				Contract: common.HexToAddress("0x0000000000000000000000000000000000001001"),
+				Data:     []byte("alpha"),
+				TxHash:   common.HexToHash("0x1111"),
+			},
+			{
+				ID:       2,
+				Contract: common.HexToAddress("0x0000000000000000000000000000000000001002"),
+				Data:     []byte("beta"),
+				TxHash:   common.HexToHash("0x2222"),
+			},
+		},
+	}
+}

--- a/eth/ethutils/receipt.go
+++ b/eth/ethutils/receipt.go
@@ -75,6 +75,9 @@ func MarshalReceipt(
 		gasPrice := new(big.Int).Add(header.BaseFee, txn.GetEffectiveGasTip(baseFee).ToBig())
 		fields["effectiveGasPrice"] = (*hexutil.Big)(gasPrice)
 	}
+	if chainConfig.Bor != nil && txn.Type() == types.StateSyncTxType {
+		fields["effectiveGasPrice"] = (*hexutil.Big)(big.NewInt(0))
+	}
 
 	// Assign receipt status.
 	fields["status"] = hexutil.Uint64(receipt.Status)

--- a/execution/consensus/aura/aura.go
+++ b/execution/consensus/aura/aura.go
@@ -859,14 +859,15 @@ func allHeadersUntil(chain consensus.ChainHeaderReader, from *types.Header, to c
 //}
 
 // FinalizeAndAssemble implements consensus.Engine
-func (c *AuRa) FinalizeAndAssemble(config *chain.Config, header *types.Header, state *state.IntraBlockState, txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chain consensus.ChainReader, syscall consensus.SystemCall, call consensus.Call, logger log.Logger) (*types.Block, types.FlatRequests, error) {
+func (c *AuRa) FinalizeAndAssemble(config *chain.Config, header *types.Header, state *state.IntraBlockState, txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chain consensus.ChainReader, syscall consensus.SystemCall, _ consensus.Call, logger log.Logger) (*types.Block, types.Receipts, types.FlatRequests, error) {
 	_, err := c.Finalize(config, header, state, txs, uncles, receipts, withdrawals, chain, syscall, false, logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Assemble and return the final block for sealing
-	return types.NewBlockForAsembling(header, txs, uncles, receipts, withdrawals), nil, nil
+	block, recs := types.NewBlockForAsembling(header, txs, uncles, receipts, withdrawals)
+	return block, recs, nil, nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/execution/consensus/aura/aura_test.go
+++ b/execution/consensus/aura/aura_test.go
@@ -44,7 +44,7 @@ import (
 func TestEmptyBlock(t *testing.T) {
 	require := require.New(t)
 	genesis := chainspec.GnosisGenesisBlock()
-	genesisBlock, _, err := core.GenesisToBlock(genesis, datadir.New(t.TempDir()), log.Root())
+	genesisBlock, _, _, err := core.GenesisToBlock(genesis, datadir.New(t.TempDir()), log.Root())
 	require.NoError(err)
 
 	genesis.Config.TerminalTotalDifficultyPassed = false

--- a/execution/consensus/clique/clique.go
+++ b/execution/consensus/clique/clique.go
@@ -387,9 +387,10 @@ func (c *Clique) Finalize(config *chain.Config, header *types.Header, state *sta
 // nor block rewards given, and returns the final block.
 func (c *Clique) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Header, state *state.IntraBlockState,
 	txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chain consensus.ChainReader, syscall consensus.SystemCall, call consensus.Call, logger log.Logger,
-) (*types.Block, types.FlatRequests, error) {
+) (*types.Block, types.Receipts, types.FlatRequests, error) {
 	// Assemble and return the final block for sealing
-	return types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals), nil, nil
+	block, recs := types.NewBlockForAsembling(header, txs, uncles, receipts, withdrawals)
+	return block, recs, nil, nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/execution/consensus/consensus.go
+++ b/execution/consensus/consensus.go
@@ -181,7 +181,7 @@ type EngineWriter interface {
 	// consensus rules that happen at finalization (e.g. block rewards).
 	FinalizeAndAssemble(config *chain.Config, header *types.Header, state *state.IntraBlockState,
 		txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chain ChainReader, syscall SystemCall, call Call, logger log.Logger,
-	) (*types.Block, types.FlatRequests, error)
+	) (*types.Block, types.Receipts, types.FlatRequests, error)
 
 	// Seal generates a new sealing request for the given input block and pushes
 	// the result into the given channel.

--- a/execution/consensus/ethash/consensus.go
+++ b/execution/consensus/ethash/consensus.go
@@ -580,15 +580,16 @@ func (ethash *Ethash) Finalize(config *chain.Config, header *types.Header, state
 func (ethash *Ethash) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Header, state *state.IntraBlockState,
 	txs types.Transactions, uncles []*types.Header, r types.Receipts, withdrawals []*types.Withdrawal,
 	chain consensus.ChainReader, syscall consensus.SystemCall, call consensus.Call, logger log.Logger,
-) (*types.Block, types.FlatRequests, error) {
+) (*types.Block, types.Receipts, types.FlatRequests, error) {
 
 	// Finalize block
 	_, err := ethash.Finalize(chainConfig, header, state, txs, uncles, r, withdrawals, chain, syscall, false, logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Header seems complete, assemble into a block and return
-	return types.NewBlock(header, txs, uncles, r, withdrawals), nil, nil
+	block, recs := types.NewBlock(header, txs, uncles, r, withdrawals)
+	return block, recs, nil, nil
 }
 
 // SealHash returns the hash of a block prior to it being sealed.

--- a/execution/consensus/merge/merge.go
+++ b/execution/consensus/merge/merge.go
@@ -229,19 +229,20 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 
 func (s *Merge) FinalizeAndAssemble(config *chain.Config, header *types.Header, state *state.IntraBlockState,
 	txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chain consensus.ChainReader, syscall consensus.SystemCall, call consensus.Call, logger log.Logger,
-) (*types.Block, types.FlatRequests, error) {
+) (*types.Block, types.Receipts, types.FlatRequests, error) {
 	if !misc.IsPoSHeader(header) {
 		return s.eth1Engine.FinalizeAndAssemble(config, header, state, txs, uncles, receipts, withdrawals, chain, syscall, call, logger)
 	}
 	header.RequestsHash = nil
 	outRequests, err := s.Finalize(config, header, state, txs, uncles, receipts, withdrawals, chain, syscall, false, logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if config.IsPrague(header.Time) {
 		header.RequestsHash = outRequests.Hash()
 	}
-	return types.NewBlockForAsembling(header, txs, uncles, receipts, withdrawals), outRequests, nil
+	block, recs := types.NewBlockForAsembling(header, txs, uncles, receipts, withdrawals)
+	return block, recs, outRequests, nil
 }
 
 func (s *Merge) SealHash(header *types.Header) (hash common.Hash) {

--- a/execution/eth1/eth1_chain_reader/chain_reader.go
+++ b/execution/eth1/eth1_chain_reader/chain_reader.go
@@ -124,7 +124,8 @@ func (c ChainReaderWriterEth1) GetBlockByHash(ctx context.Context, hash common.H
 		log.Warn("[engine] GetBlockByHash", "err", err)
 		return nil
 	}
-	return types.NewBlock(header, txs, nil, nil, body.Withdrawals)
+	block, _ := types.NewBlock(header, txs, nil, nil, body.Withdrawals)
+	return block
 }
 
 func (c ChainReaderWriterEth1) GetBlockByNumber(ctx context.Context, number uint64) *types.Block {
@@ -153,7 +154,8 @@ func (c ChainReaderWriterEth1) GetBlockByNumber(ctx context.Context, number uint
 		log.Warn("[engine] GetBlockByNumber", "err", err)
 		return nil
 	}
-	return types.NewBlock(header, txs, nil, nil, body.Withdrawals)
+	block, _ := types.NewBlock(header, txs, nil, nil, body.Withdrawals)
+	return block
 }
 
 func (c ChainReaderWriterEth1) GetHeaderByHash(ctx context.Context, hash common.Hash) *types.Header {

--- a/execution/eth1/eth1_utils/grpc_test.go
+++ b/execution/eth1/eth1_utils/grpc_test.go
@@ -83,7 +83,8 @@ func makeBlock(txCount, uncleCount, withdrawalCount int) *types.Block {
 			Amount:    uint64(10 * i),
 		}
 	}
-	return types.NewBlock(header, txs, uncles, receipts, withdrawals)
+	block, _ := types.NewBlock(header, txs, uncles, receipts, withdrawals)
+	return block
 }
 
 func TestBlockRpcConversion(t *testing.T) {

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -160,7 +160,7 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 	switch {
 	case txTask.TxIndex == -1:
 		if txTask.BlockNum == 0 {
-			_, ibs, err = core.GenesisToBlock(rw.execArgs.Genesis, rw.execArgs.Dirs, rw.logger)
+			_, _, ibs, err = core.GenesisToBlock(rw.execArgs.Genesis, rw.execArgs.Dirs, rw.logger)
 			if err != nil {
 				panic(fmt.Errorf("GenesisToBlock: %w", err))
 			}

--- a/execution/exec3/state.go
+++ b/execution/exec3/state.go
@@ -224,7 +224,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 		if txTask.BlockNum == 0 {
 
 			//fmt.Printf("txNum=%d, blockNum=%d, Genesis\n", txTask.TxNum, txTask.BlockNum)
-			_, ibs, err = core.GenesisToBlock(rw.genesis, rw.dirs, rw.logger)
+			_, _, ibs, err = core.GenesisToBlock(rw.genesis, rw.dirs, rw.logger)
 			if err != nil {
 				panic(err)
 			}
@@ -257,7 +257,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 		}
 
 		if isMining {
-			_, _, err = rw.engine.FinalizeAndAssemble(cc, types.CopyHeader(header), ibs, txTask.Txs, txTask.Uncles, txTask.BlockReceipts, txTask.Withdrawals, rw.chain, syscall, nil, rw.logger)
+			_, _, _, err = rw.engine.FinalizeAndAssemble(cc, types.CopyHeader(header), ibs, txTask.Txs, txTask.Uncles, txTask.BlockReceipts, txTask.Withdrawals, rw.chain, syscall, nil, rw.logger)
 		} else {
 			_, err = rw.engine.Finalize(cc, types.CopyHeader(header), ibs, txTask.Txs, txTask.Uncles, txTask.BlockReceipts, txTask.Withdrawals, rw.chain, syscall, skipPostEvaluation, rw.logger)
 		}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -410,6 +410,25 @@ func (pe *parallelExecutor) processResultQueue(ctx context.Context, inputTxNum u
 		}
 
 		if txTask.Final {
+			// PIP-74: ensure that logs from state-sync tx are applied
+			// this is needed as the state-sync txs are skipped during execution,
+			// but we still want to apply their logs to the state
+			if pe.cfg.chainConfig.Bor != nil && pe.cfg.chainConfig.Bor.IsStateSync(txTask.BlockNum) {
+				if len(txTask.BlockReceipts) > 0 {
+					last := txTask.BlockReceipts[len(txTask.BlockReceipts)-1]
+					if last != nil && last.Type == types.StateSyncTxType {
+						// Ensure logs from the state-sync receipt are applied
+						if err := pe.rs.ApplyLogsAndTraces(&state.TxTask{
+							BlockNum:      txTask.BlockNum,
+							BlockReceipts: []*types.Receipt{last},
+							Logs:          last.Logs,
+						}, pe.rs.Domains()); err != nil {
+							return outputTxNum, conflicts, triggers, processedBlockNum, false,
+								fmt.Errorf("ParallelExecutionState.Apply state-sync logs addition error: %w", err)
+						}
+					}
+				}
+			}
 			pe.rs.SetTxNum(txTask.TxNum, txTask.BlockNum)
 			err := pe.rs.ApplyState(ctx, txTask)
 			if err != nil {
@@ -528,6 +547,10 @@ func (pe *parallelExecutor) wait() error {
 
 func (pe *parallelExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp *core.GasPool) (bool, error) {
 	for _, txTask := range tasks {
+		// skip state sync txs
+		if txTask.Tx != nil && txTask.Tx.Type() == types.StateSyncTxType {
+			continue
+		}
 		if txTask.Sender() != nil {
 			if ok := pe.rs.RegisterSender(txTask); ok {
 				pe.rs.AddWork(ctx, txTask, pe.in)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -30,7 +30,7 @@ func (se *serialExecutor) wait() error {
 	return nil
 }
 
-func (se *serialExecutor) status(ctx context.Context, commitThreshold uint64) error {
+func (se *serialExecutor) status(_ context.Context, _ uint64) error {
 	return nil
 }
 
@@ -38,6 +38,10 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 	for _, txTask := range tasks {
 		if txTask.Error != nil {
 			return false, nil
+		}
+		// skip state sync txs
+		if txTask.Tx != nil && txTask.Tx.Type() == types.StateSyncTxType {
+			continue
 		}
 		if gp != nil {
 			se.applyWorker.SetGaspool(gp)
@@ -62,13 +66,24 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 
 			if txTask.Final {
 				if !se.isMining && !se.skipPostEvaluation && !se.execStage.CurrentSyncCycle.IsInitialCycle {
-					// note this assumes the bloach reciepts is a fixed array shared by
-					// all tasks - if that changes this will need to change - robably need to
+					// note this assumes the block receipts is a fixed array shared by
+					// all tasks - if that changes this will need to change - probably need to
 					// add this to the executor
-					se.cfg.notifications.RecentLogs.Add(txTask.BlockReceipts)
+					receiptsToPush := txTask.BlockReceipts
+					// polygon state-sync behavior
+					if se.cfg.chainConfig.Bor != nil && se.cfg.chainConfig.Bor.IsStateSync(txTask.BlockNum) {
+						// Nothing to do here
+						// Post StateSyncBlock (PIP-74), `FinalizeAndAssemble` already appends the state-sync receipt.
+						// It included in `receiptsToPush`, so we don't add it twice.
+						// Keeping the comment to make the state-sync handling explicit.
+					}
+					se.cfg.notifications.RecentLogs.Add(receiptsToPush)
 				}
 				checkReceipts := !se.cfg.vmConfig.StatelessExec && se.cfg.chainConfig.IsByzantium(txTask.BlockNum) && !se.cfg.vmConfig.NoReceipts && !se.isMining
-				if txTask.BlockNum > 0 && !se.skipPostEvaluation { //Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
+				if txTask.BlockNum > 0 && !se.skipPostEvaluation {
+					// Disable check for genesis.
+					// Maybe we need to somehow improve it in the future
+					// to satisfy TestExecutionSpec
 					if err := core.BlockPostValidation(se.gasUsed, se.blobGasUsed, checkReceipts, txTask.BlockReceipts, txTask.Header, se.isMining, txTask.Txs, se.cfg.chainConfig, se.logger); err != nil {
 						return fmt.Errorf("%w, txnIdx=%d, %v", consensus.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
@@ -124,7 +139,7 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 			}
 		} else {
 			if se.cfg.chainConfig.Bor != nil && txTask.TxIndex >= 1 {
-				// get last receipt and store the last log index + 1
+				// get the last receipt and store the last log index + 1
 				lastReceipt := txTask.BlockReceipts[txTask.TxIndex-1]
 				if lastReceipt == nil {
 					if se.skipPostEvaluation {

--- a/execution/stagedsync/stage_mining_finish.go
+++ b/execution/stagedsync/stage_mining_finish.go
@@ -67,8 +67,8 @@ func SpawnMiningFinishStage(s *StageState, tx kv.RwTx, cfg MiningFinishCfg, quit
 	//	continue
 	//}
 
-	block := types.NewBlockForAsembling(current.Header, current.Txns, current.Uncles, current.Receipts, current.Withdrawals)
-	blockWithReceipts := &types.BlockWithReceipts{Block: block, Receipts: current.Receipts, Requests: current.Requests}
+	block, receipts := types.NewBlockForAsembling(current.Header, current.Txns, current.Uncles, current.Receipts, current.Withdrawals)
+	blockWithReceipts := &types.BlockWithReceipts{Block: block, Receipts: receipts, Requests: current.Requests}
 	*current = MiningBlock{} // hack to clean global data
 
 	//sealHash := engine.SealHash(block.Header())

--- a/execution/stages/mock/accessors_indexes_test.go
+++ b/execution/stages/mock/accessors_indexes_test.go
@@ -68,7 +68,7 @@ func TestLookupStorage(t *testing.T) {
 			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), uint256.NewInt(333), 3333, uint256.NewInt(33333), []byte{0x33, 0x33, 0x33})
 			txs := []types.Transaction{tx1, tx2, tx3}
 
-			block := types.NewBlock(&types.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
+			block, _ := types.NewBlock(&types.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
 
 			// Check that no transactions entries are in a pristine database
 			for i, txn := range txs {

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -89,14 +89,14 @@ var (
 	// diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 	// diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 
-	validatorHeaderBytesLength = length.Addr + 20 // address + power
+	validatorHeaderBytesLength = length.Addr + 20 // address and power
 
 	// MaxCheckpointLength is the maximum number of blocks that can be requested for constructing a checkpoint root hash
 	MaxCheckpointLength = uint64(math.Pow(2, 15))
 )
 
 // Various error messages to mark blocks invalid. These should be private to
-// prevent engine specific errors from being referenced in the remainder of the
+// prevent the engine-specific errors from being referenced in the remainder of the
 // codebase, inherently breaking if the engine is swapped out. Please put common
 // error types into the consensus package.
 var (
@@ -124,25 +124,25 @@ var (
 	// to contain a 65 byte secp256k1 signature.
 	errMissingSignature = errors.New("extra-data 65 byte signature suffix missing")
 
-	// errExtraValidators is returned if non-sprint-end block contain validator data in
+	// errExtraValidators is returned if non-sprint-end block contains validator data in
 	// their extra-data fields.
 	errExtraValidators = errors.New("non-sprint-end block contains extra validator list")
 
 	// errInvalidSprintValidators is returned if a block contains an
-	// invalid list of validators (i.e. non divisible by 40 bytes).
+	// invalid list of validators (i.e., non-divisible by 40 bytes).
 	errInvalidSprintValidators = errors.New("invalid validator list on sprint end block")
 
 	// errInvalidMixDigest is returned if a block's mix digest is non-zero.
 	errInvalidMixDigest = errors.New("non-zero mix digest")
 
-	// errInvalidUncleHash is returned if a block contains an non-empty uncle list.
+	// errInvalidUncleHash is returned if a block contains a non-empty uncle list.
 	errInvalidUncleHash = errors.New("non empty uncle hash")
 
-	// errInvalidDifficulty is returned if the difficulty of a block neither 1 or 2.
+	// errInvalidDifficulty is returned if the difficulty of a block neither 1 nor 2.
 	errInvalidDifficulty = errors.New("invalid difficulty")
 
 	// ErrInvalidTimestamp is returned if the timestamp of a block is lower than
-	// the previous block's timestamp + the minimum block period.
+	// the previous block's timestamp and the minimum block period.
 	ErrInvalidTimestamp = errors.New("invalid timestamp")
 
 	// errOutOfRangeChain is returned if an authorization list is attempted to
@@ -302,7 +302,7 @@ func ValidateHeaderTime(
 		return err
 	}
 
-	// Post Bhilai HF, reject blocks form non-primary producers if they're earlier than the expected time
+	// Post Bhilai HF, reject blocks from non-primary producers if they're earlier than the expected time
 	if config.IsBhilai(header.Number.Uint64()) && succession != 0 {
 		if header.Time > uint64(now.Unix()) {
 			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
@@ -316,12 +316,12 @@ func ValidateHeaderTime(
 	return nil
 }
 
-// BorRLP returns the rlp bytes which needs to be signed for the bor
-// sealing. The RLP to sign consists of the entire header apart from the 65 byte signature
+// BorRLP returns the rlp bytes which need to be signed for the bor sealing.
+// The RLP to sign consists of the entire header apart from the 65-byte signature
 // contained at the end of the extra data.
 //
-// Note, the method requires the extra data to be at least 65 bytes, otherwise it
-// panics. This is done to avoid accidentally using both forms (signature present
+// Note, the method requires the extra data to be at least 65 bytes, otherwise it panics.
+// This is done to avoid accidentally using both forms (signature present
 // or not), which could be abused to produce different hashes for the same header.
 func BorRLP(header *types.Header, c *borcfg.BorConfig) []byte {
 	b := new(bytes.Buffer)
@@ -434,7 +434,7 @@ func New(
 	return c
 }
 
-// NewRo is used by the rpcdaemon and tests which need read only access to the provided data services
+// NewRo is used by the rpc daemon and tests which need read-only access to the provided data services
 func NewRo(chainConfig *chain.Config, db kv.RoDB, blockReader services.FullBlockReader, logger log.Logger) *Bor {
 	// get bor config
 	borConfig := chainConfig.Bor.(*borcfg.BorConfig)
@@ -488,12 +488,12 @@ func (c *Bor) Author(header *types.Header) (common.Address, error) {
 }
 
 // VerifyHeader checks whether a header conforms to the consensus rules.
-func (c *Bor) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error {
+func (c *Bor) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, _ bool) error {
 	return c.verifyHeader(chain, header, nil)
 }
 
-// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
-// method returns a quit channel to abort the operations and a results channel to
+// VerifyHeaders is similar to VerifyHeader but verifies a batch of headers.
+// The method returns a quit channel to abort the operations and a result channel to
 // retrieve the async verifications (the order is that of the input slice).
 func (c *Bor) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, _ []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
@@ -577,7 +577,8 @@ func ValidateHeaderExtraLength(extraBytes []byte) error {
 	return nil
 }
 
-// ValidateHeaderSprintValidators validates that the extra-data contains a validators list only in the last header of a sprint.
+// ValidateHeaderSprintValidators validates that the extra-data contains a validators'
+// list only in the last header of a sprint.
 func ValidateHeaderSprintValidators(header *types.Header, config *borcfg.BorConfig) error {
 	number := header.Number.Uint64()
 	isSprintEnd := config.IsSprintEnd(number)
@@ -932,7 +933,7 @@ func (c *Bor) verifySeal(chain ChainHeaderReader, header *types.Header, parents 
 
 // Prepare implements consensus.Engine, preparing all the consensus fields of the
 // header for running the transactions on top.
-func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, state *state.IntraBlockState) error {
+func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, _ *state.IntraBlockState) error {
 	// If the block isn't a checkpoint, cast a random vote (good enough for now)
 	header.Coinbase = common.Address{}
 	header.Nonce = types.BlockNonce{}
@@ -1048,7 +1049,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	var succession int
 	var err error
 	signer := c.authorizedSigner.Load().signer
-	// if signer is not empty
+	// if the signer is not empty
 	if !bytes.Equal(signer.Bytes(), common.Address{}.Bytes()) {
 		succession, err = validatorSet.GetSignerSuccessionNumber(signer, number)
 		if err != nil {
@@ -1061,9 +1062,10 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	if header.Time < uint64(now.Unix()) {
 		header.Time = uint64(now.Unix())
 	} else {
-		// For primary validators, wait until the current block production window
-		// starts. This prevents bor from starting to build next block before time
-		// as we'd like to wait for new transactions. Although this change doesn't
+		// For primary validators, wait until the current block production window starts.
+		// This prevents bor from starting to build the next block before time
+		// as we'd like to wait for new transactions.
+		// Although this change doesn't
 		// need a check for hard fork as it doesn't change any consensus rules, we
 		// still keep it for safety and testing.
 		if c.config.IsBhilai(number) && succession == 0 {
@@ -1075,7 +1077,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	return nil
 }
 
-func (c *Bor) CalculateRewards(config *chain.Config, header *types.Header, uncles []*types.Header, syscall consensus.SystemCall,
+func (c *Bor) CalculateRewards(_ *chain.Config, _ *types.Header, _ []*types.Header, _ consensus.SystemCall,
 ) ([]consensus.Reward, error) {
 	return []consensus.Reward{}, nil
 }
@@ -1107,8 +1109,10 @@ func (c *Bor) Finalize(config *chain.Config, header *types.Header, state *state.
 				return nil, err
 			}
 
-			// commit states
-			if err := c.CommitStates(state, header, cx, syscall, logger, false); err != nil {
+			// Commit States
+			// Unlike `FinalizeAndAssemble`, we do not use the returned StateSyncData here,
+			// since receipts/tx assembly happens only in FinalizeAndAssemble.
+			if _, err := c.CommitStates(state, header, cx, syscall, logger, false); err != nil {
 				err := fmt.Errorf("Finalize.CommitStates: %w", err)
 				c.logger.Error("[bor] Error while committing states", "err", err)
 				return nil, err
@@ -1124,6 +1128,9 @@ func (c *Bor) Finalize(config *chain.Config, header *types.Header, state *state.
 	// Set state sync data to blockchain
 	// bc := chain.(*core.BlockChain)
 	// bc.SetStateSync(stateSyncData)
+
+	// PIP-74: Finalize does not append txs/receipts (that’s done in FinalizeAndAssemble)
+
 	return nil, nil
 }
 
@@ -1137,7 +1144,7 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state *state.Intra
 
 			for addr, account := range allocs {
 				c.logger.Trace("[bor] change contract code", "address", addr)
-				state.SetCode(addr, account.Code)
+				_ = state.SetCode(addr, account.Code)
 			}
 		}
 	}
@@ -1147,21 +1154,31 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state *state.Intra
 
 // FinalizeAndAssemble implements consensus.Engine, ensuring no uncles are set,
 // nor block rewards given, and returns the final block.
-func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Header, state *state.IntraBlockState,
-	txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal,
-	chain consensus.ChainReader, syscall consensus.SystemCall, call consensus.Call, logger log.Logger,
-) (*types.Block, types.FlatRequests, error) {
+func (c *Bor) FinalizeAndAssemble(
+	_ *chain.Config,
+	header *types.Header,
+	state *state.IntraBlockState,
+	txs types.Transactions,
+	_ []*types.Header,
+	receipts types.Receipts,
+	withdrawals []*types.Withdrawal,
+	chain consensus.ChainReader,
+	syscall consensus.SystemCall,
+	_ consensus.Call,
+	logger log.Logger) (*types.Block, types.Receipts, types.FlatRequests, error) {
 	// stateSyncData := []*types.StateSyncData{}
 
 	headerNumber := header.Number.Uint64()
 
 	if withdrawals != nil || header.WithdrawalsHash != nil {
-		return nil, nil, consensus.ErrUnexpectedWithdrawals
+		return nil, nil, nil, consensus.ErrUnexpectedWithdrawals
 	}
 
 	if header.RequestsHash != nil {
-		return nil, nil, consensus.ErrUnexpectedRequests
+		return nil, nil, nil, consensus.ErrUnexpectedRequests
 	}
+
+	var execStateSync []*types.StateSyncData
 
 	if c.config.IsSprintStart(headerNumber) {
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
@@ -1171,37 +1188,48 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 			if err := c.checkAndCommitSpan(state, header, cx, syscall); err != nil {
 				err := fmt.Errorf("FinalizeAndAssemble.checkAndCommitSpan: %w", err)
 				c.logger.Error("[bor] committing span", "err", err)
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
-			// commit states
-			if err := c.CommitStates(state, header, cx, syscall, logger, true); err != nil {
+			// commit states, get executed state sync data
+			var err error
+			execStateSync, err = c.CommitStates(state, header, cx, syscall, logger, true)
+			if err != nil {
 				err := fmt.Errorf("FinalizeAndAssemble.CommitStates: %w", err)
 				c.logger.Error("[bor] committing states", "err", err)
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		}
 	}
 
 	if err := c.changeContractCodeIfNeeded(headerNumber, state); err != nil {
 		c.logger.Error("[bor] Error changing contract code", "err", err)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Assemble block
-	block := types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals)
+	block, recs := types.NewBlockForAsembling(header, txs, nil, receipts, withdrawals)
 
 	// set state sync
 	// bc := chain.(*core.BlockChain)
 	// bc.SetStateSync(stateSyncData)
 
+	// PIP-74: append StateSyncTx and receipt post-fork if any events executed
+	if c.config.IsStateSync(headerNumber) && len(execStateSync) > 0 {
+		c.logger.Info("FinalizeAndAssemble: Appending state sync txs", "count", len(execStateSync))
+		stateSyncTx := &types.StateSyncTx{StateSyncData: execStateSync}
+		txs = append(txs, stateSyncTx)
+		stateSyncReceipt := newStateSyncReceipt(stateSyncTx, receipts, state, header, txs)
+		recs = append(recs, stateSyncReceipt)
+	}
+
 	// return the final block for sealing
-	return block, nil, nil
+	return block, recs, nil, nil
 }
 
 func (c *Bor) Initialize(config *chain.Config, chain consensus.ChainHeaderReader, header *types.Header,
-	state *state.IntraBlockState, syscall consensus.SysCallCustom, logger log.Logger, tracer *tracing.Hooks) {
+	state *state.IntraBlockState, _ consensus.SysCallCustom, _ log.Logger, _ *tracing.Hooks) {
 	if chain != nil && chain.Config().IsBhilai(header.Number.Uint64()) {
-		misc.StoreBlockHashesEip2935(header, state, config, chain)
+		_ = misc.StoreBlockHashesEip2935(header, state, config, chain)
 	}
 }
 
@@ -1261,15 +1289,15 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.B
 	}
 
 	var delay time.Duration
-	// Sweet, the protocol permits us to sign the block, wait for our time
+	// The protocol permits us to sign the block, wait for our time
 	if c.config.IsBhilai(header.Number.Uint64()) && successionNumber == 0 {
 		// For primary producers, set the delay to `header.Time - block time` instead of `header.Time`
-		// for early block announcement instead of waiting for full block time.
+		// for the early block announcement instead of waiting for full block time.
 		delay = time.Until(time.Unix(int64(header.Time)-int64(c.config.CalculatePeriod(number)), 0))
 	} else {
 		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time
 	}
-	// wiggle was already accounted for in header.Time, this is just for logging
+	// wiggle was already accounted for in the header.Time, this is just for logging
 	wiggle := time.Duration(successionNumber) * time.Duration(c.config.CalculateBackupMultiplier(number)) * time.Second
 
 	// Sign all the things!
@@ -1412,12 +1440,12 @@ func (c *Bor) SealHash(header *types.Header) common.Hash {
 	return SealHash(header, c.config)
 }
 
-func (c *Bor) IsServiceTransaction(sender common.Address, syscall consensus.SystemCall) bool {
+func (c *Bor) IsServiceTransaction(_ common.Address, _ consensus.SystemCall) bool {
 	return false
 }
 
-// Depricated: To get the API use jsonrpc.APIList
-func (c *Bor) APIs(chain consensus.ChainHeaderReader) []rpc.API {
+// APIs method is deprecated: To get the APIs use jsonrpc.APIList
+func (c *Bor) APIs(_ consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{}
 }
 
@@ -1479,8 +1507,8 @@ func (c *Bor) checkAndCommitSpan(
 
 	// Whenever `checkAndCommitSpan` is called for the first time, during the start of 'technically'
 	// second sprint, we need the 0th as well as the 1st span. The contract returns an empty
-	// span (i.e. all fields set to 0). Span 0 doesn't need to be committed explicitly and
-	// is committed eventually when we commit 1st span (as per the contract). The check below
+	// span (i.e., all fields set to 0). Span 0 doesn't need to be committed explicitly and
+	// is committed eventually when we commit the 1st span (as per the contract). The check below
 	// takes care of that and commits the 1st span (hence the `currentSpan.Id+1` param).
 	if currentSpan.EndBlock == 0 {
 		if err := c.fetchAndCommitSpan(uint64(currentSpan.Id+1), state, header, chain, syscall); err != nil {
@@ -1488,7 +1516,7 @@ func (c *Bor) checkAndCommitSpan(
 		}
 	}
 
-	// For subsequent calls, commit the next span on the first block of the last sprint of a span
+	// For later calls, commit the next span on the first block of the span's last sprint
 	sprintLength := c.config.CalculateSprintLength(headerNumber)
 	if currentSpan.EndBlock > sprintLength && currentSpan.EndBlock-sprintLength+1 == headerNumber {
 		if err := c.fetchAndCommitSpan(uint64(currentSpan.Id+1), state, header, chain, syscall); err != nil {
@@ -1619,13 +1647,13 @@ func (c *Bor) getHeaderByNumber(ctx context.Context, tx kv.Tx, number uint64) (*
 
 // CommitStates commit states
 func (c *Bor) CommitStates(
-	state *state.IntraBlockState,
+	_ *state.IntraBlockState,
 	header *types.Header,
 	chain statefull.ChainContext,
 	syscall consensus.SystemCall,
 	logger log.Logger,
 	fetchEventsWithingTime bool,
-) error {
+) ([]*types.StateSyncData, error) {
 	blockNum := header.Number.Uint64()
 
 	if c.useBridgeReader {
@@ -1637,7 +1665,7 @@ func (c *Bor) CommitStates(
 			sprintLength := c.config.CalculateSprintLength(blockNum)
 
 			if blockNum < sprintLength {
-				return nil
+				return nil, nil
 			}
 
 			prevSprintStart := chain.Chain.GetHeaderByNumber(blockNum - sprintLength)
@@ -1663,29 +1691,43 @@ func (c *Bor) CommitStates(
 
 			events, err = c.bridgeReader.EventsWithinTime(ctx, timeFrom, timeTo)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		} else {
 			events, err = c.bridgeReader.Events(ctx, header.Hash(), blockNum)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
+		execStateSync := make([]*types.StateSyncData, 0, len(events))
+
 		for _, event := range events {
-			_, err := syscall(*event.To(), event.Data())
-			if err != nil {
-				return err
+			if _, err := syscall(*event.To(), event.Data()); err != nil {
+				return nil, err
 			}
+			var ev types.StateSyncData
+			if err := rlp.DecodeBytes(event.Data(), &ev); err != nil {
+				continue // not a state-sync event, skip
+			}
+
+			execStateSync = append(execStateSync, &types.StateSyncData{
+				ID:       ev.ID,
+				Contract: ev.Contract,
+				Data:     ev.Data,
+				TxHash:   ev.TxHash,
+			})
 		}
-		return nil
+		// Return the executed events
+		// This is harmless pre-fork, because the caller will decide whether to use it or not, based on HF status.
+		return execStateSync, nil
 	}
 
 	events := chain.Chain.BorEventsByBlock(header.Hash(), blockNum)
 
-	// set this true to check the current stored events vs the current heimdall contents
-	// it should be false for non debug becuase it causes an additional call to the
-	// heimdall service to check that we have the same events as the remote service
+	// Set this true to check the current stored events vs. the current heimdall contents.
+	// It should be false for non-debug, because it causes an additional call to the
+	// heimdall service to check that we have the same events as the remote service.
 	const checkEvents = false
 
 	if checkEvents {
@@ -1693,17 +1735,17 @@ func (c *Bor) CommitStates(
 			header, chain.Chain.GetHeaderByNumber(blockNum-c.config.CalculateSprintLength(blockNum)),
 			c.chainConfig.ChainID.String(), chain.Chain.BorStartEventId(header.Hash(), blockNum),
 			events, c.HeimdallClient, c.config, logger); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	for _, event := range events {
 		if err := c.stateReceiver.CommitState(event, syscall); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (c *Bor) SetHeimdallClient(h heimdall.Client) {
@@ -1810,7 +1852,7 @@ func (c *Bor) GetTransferFunc() evmtypes.TransferFunc {
 	return BorTransfer
 }
 
-// AddFeeTransferLog adds fee transfer log into state
+// AddFeeTransferLog adds fee transfer log into the state
 // Deprecating transfer log and will be removed in future fork. PLEASE DO NOT USE this transfer log going forward. Parameters won't get updated as expected going forward with EIP1559
 func AddFeeTransferLog(ibs evmtypes.IntraBlockState, sender common.Address, coinbase common.Address, result *evmtypes.ExecutionResult) {
 	output1 := result.SenderInitBalance.Clone()
@@ -1860,14 +1902,14 @@ func (c *Bor) TxDependencies(h *types.Header) [][]int {
 	return blockExtraData.TxDependencies
 }
 
-// In bor, RLP encoding of BlockExtraData will be stored in the Extra field in the header
+// BlockExtraData for bor, where RLP encoding will be stored in the Extra field of the header
 type BlockExtraData struct {
 	// Validator bytes of bor
 	ValidatorBytes []byte
 
-	// length of TxDependencies          ->   n (n = number of transactions in the block)
-	// length of TxDependencies[i]       ->   k (k = a whole number)
-	// k elements in TxDependencies[i]   ->   transaction indexes on which transaction i is dependent on
+	// length of TxDependencies -> n (n = number of transactions in the block)
+	// length of TxDependencies[i] -> k (k = a whole number)
+	// k elements in TxDependencies[i] -> transaction indexes on which transaction i is dependent on
 	TxDependencies [][]int
 }
 
@@ -1898,4 +1940,34 @@ func VerifyUncles(uncles []*types.Header) error {
 	}
 
 	return nil
+}
+
+// newStateSyncReceipt creates a new receipt for the StateSyncTx
+func newStateSyncReceipt(tx types.Transaction, prev types.Receipts, state *state.IntraBlockState, header *types.Header, txs types.Transactions) *types.Receipt {
+	// Slice logs since previous receipts
+	allLogs := state.Logs()
+	logsFromReceiptCount := countLogsFromReceipts(prev)
+	stateSyncLogs := allLogs[logsFromReceiptCount:]
+
+	r := &types.Receipt{
+		Type:              tx.Type(),
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: header.GasUsed,
+		GasUsed:           0,
+		TxHash:            tx.Hash(),
+		Logs:              stateSyncLogs,
+		BlockNumber:       header.Number,
+		TransactionIndex:  uint(len(txs) - 1),
+	}
+	r.Bloom = types.CreateBloom(types.Receipts{r})
+	return r
+}
+
+// countLogsFromReceipts counts the total number of logs in the given receipts.
+func countLogsFromReceipts(receipts types.Receipts) int {
+	count := 0
+	for _, r := range receipts {
+		count += len(r.Logs)
+	}
+	return count
 }

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1166,7 +1166,6 @@ func (c *Bor) FinalizeAndAssemble(
 	syscall consensus.SystemCall,
 	_ consensus.Call,
 	logger log.Logger) (*types.Block, types.Receipts, types.FlatRequests, error) {
-	// stateSyncData := []*types.StateSyncData{}
 
 	headerNumber := header.Number.Uint64()
 

--- a/polygon/bor/bor_internal_test.go
+++ b/polygon/bor/bor_internal_test.go
@@ -130,7 +130,7 @@ func TestCommitStatesIndore(t *testing.T) {
 		return nil, nil
 	}
 
-	err := bor.CommitStates(nil, header, statefull.ChainContext{
+	_, err := bor.CommitStates(nil, header, statefull.ChainContext{
 		Chain: cr,
 	}, syscall, nil, true)
 

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -44,6 +44,7 @@ type BorConfig struct {
 	NapoliBlock                *big.Int          `json:"napoliBlock"`                // Napoli switch block (nil = no fork, 0 = already on Napoli)
 	AhmedabadBlock             *big.Int          `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on Ahmedabad)
 	BhilaiBlock                *big.Int          `json:"bhilaiBlock"`                // Bhilai switch block (nil = no fork, 0 = already on Ahmedabad)
+	StateSyncBlock             *big.Int          `json:"stateSyncBlock"`             // StateSync switch block (nil = no fork, 0 = already on StateSync) // TODO define better name
 	StateSyncConfirmationDelay map[string]uint64 `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 
 	sprints sprints
@@ -140,9 +141,9 @@ func (c *BorConfig) IsIndore(number uint64) bool {
 	return isForked(c.IndoreBlock, number)
 }
 
-// IsAgra returns whether num is either equal to the Agra fork block or greater.
+// IsAgra returns whether the num is either equal to the Agra fork block or greater.
 // The Agra hard fork is based on the Shanghai hard fork, but it doesn't include withdrawals.
-// Also Agra is activated based on the block number rather than the timestamp.
+// Also, Agra is activated based on the block number rather than the timestamp.
 // Refer to https://forum.polygon.technology/t/pip-28-agra-hardfork
 func (c *BorConfig) IsAgra(num uint64) bool {
 	return isForked(c.AgraBlock, num)
@@ -175,6 +176,14 @@ func (c *BorConfig) IsBhilai(number uint64) bool {
 
 func (c *BorConfig) GetBhilaiBlock() *big.Int {
 	return c.BhilaiBlock
+}
+
+func (c *BorConfig) IsStateSync(number uint64) bool {
+	return isForked(c.StateSyncBlock, number)
+}
+
+func (c *BorConfig) GetStateSyncBlock() *big.Int {
+	return c.StateSyncBlock
 }
 
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {

--- a/polygon/p2p/message_listener_test.go
+++ b/polygon/p2p/message_listener_test.go
@@ -433,8 +433,9 @@ func blockHeadersPacket66Bytes(t *testing.T, requestId uint64, headers []*types.
 }
 
 func newMockNewBlockPacketBytes(t *testing.T) []byte {
+	block, _ := types.NewBlock(newMockBlockHeaders(1)[0], nil, nil, nil, nil)
 	newBlockPacket := eth.NewBlockPacket{
-		Block: types.NewBlock(newMockBlockHeaders(1)[0], nil, nil, nil, nil),
+		Block: block,
 	}
 	newBlockPacketBytes, err := rlp.EncodeToBytes(&newBlockPacket)
 	require.NoError(t, err)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -194,7 +194,7 @@ func (t *StateTest) RunNoVerify(tx kv.TemporalRwTx, subtest StateSubtest, vmconf
 		return nil, common.Hash{}, 0, testutil.UnsupportedForkError{Name: subtest.Fork}
 	}
 	vmconfig.ExtraEips = eips
-	block, _, err := core.GenesisToBlock(t.genesis(config), dirs, log.Root())
+	block, _, _, err := core.GenesisToBlock(t.genesis(config), dirs, log.Root())
 	if err != nil {
 		return nil, common.Hash{}, 0, testutil.UnsupportedForkError{Name: subtest.Fork}
 	}

--- a/tests/statedb_insert_chain_transaction_test.go
+++ b/tests/statedb_insert_chain_transaction_test.go
@@ -67,7 +67,7 @@ func TestInsertIncorrectStateRootDifferentAccounts(t *testing.T) {
 		t.Fatal("roots are the same")
 	}
 
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 	if err = m.InsertChain(incorrectChain); err == nil {
 		t.Fatal("should fail")
@@ -150,7 +150,7 @@ func TestInsertIncorrectStateRootSameAccount(t *testing.T) {
 		t.Fatal("roots are the same")
 	}
 
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 	if err = m.InsertChain(incorrectChain); err == nil {
 		t.Fatal("should fail")
@@ -224,7 +224,7 @@ func TestInsertIncorrectStateRootSameAccountSameAmount(t *testing.T) {
 	incorrectHeader := types.CopyHeader(chain.Headers[0]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[1].Root
 
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 	if err = m.InsertChain(incorrectChain); err == nil {
 		t.Fatal("should fail")
@@ -298,7 +298,7 @@ func TestInsertIncorrectStateRootAllFundsRoot(t *testing.T) {
 	incorrectHeader := types.CopyHeader(chain.Headers[0]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[1].Root
 
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 	if err = m.InsertChain(incorrectChain); err == nil {
 		t.Fatal("should fail")
@@ -371,7 +371,7 @@ func TestInsertIncorrectStateRootAllFunds(t *testing.T) {
 	// BLOCK 1
 	incorrectHeader := types.CopyHeader(chain.Headers[0]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[1].Root
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[0].Transactions(), chain.Blocks[0].Uncles(), chain.Receipts[0], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 
 	if err = m.InsertChain(incorrectChain); err == nil {
@@ -471,7 +471,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 
 	incorrectHeader := types.CopyHeader(chain.Headers[1]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[0].Root
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[1].Transactions(), chain.Blocks[1].Uncles(), chain.Receipts[1], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[1].Transactions(), chain.Blocks[1].Uncles(), chain.Receipts[1], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 
 	// BLOCK 2 - INCORRECT
@@ -610,7 +610,7 @@ func TestAccountCreateIncorrectRoot(t *testing.T) {
 	// BLOCK 3 - INCORRECT
 	incorrectHeader := types.CopyHeader(chain.Headers[2]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[1].Root
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[2].Transactions(), chain.Blocks[2].Uncles(), chain.Receipts[2], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[2].Transactions(), chain.Blocks[2].Uncles(), chain.Receipts[2], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 
 	if err = m.InsertChain(incorrectChain); err == nil {
@@ -715,7 +715,7 @@ func TestAccountUpdateIncorrectRoot(t *testing.T) {
 	// BLOCK 4 - INCORRECT
 	incorrectHeader := types.CopyHeader(chain.Headers[3]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[1].Root
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[3].Transactions(), chain.Blocks[3].Uncles(), chain.Receipts[3], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[3].Transactions(), chain.Blocks[3].Uncles(), chain.Receipts[3], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 
 	if err = m.InsertChain(incorrectChain); err == nil {
@@ -819,7 +819,7 @@ func TestAccountDeleteIncorrectRoot(t *testing.T) {
 	// BLOCK 4 - INCORRECT
 	incorrectHeader := types.CopyHeader(chain.Headers[3]) // Copy header, not just pointer
 	incorrectHeader.Root = chain.Headers[1].Root
-	incorrectBlock := types.NewBlock(incorrectHeader, chain.Blocks[3].Transactions(), chain.Blocks[3].Uncles(), chain.Receipts[3], nil)
+	incorrectBlock, _ := types.NewBlock(incorrectHeader, chain.Blocks[3].Transactions(), chain.Blocks[3].Uncles(), chain.Receipts[3], nil)
 	incorrectChain := &core.ChainPack{Blocks: []*types.Block{incorrectBlock}, Headers: []*types.Header{incorrectHeader}, TopBlock: incorrectBlock}
 	if err = m.InsertChain(incorrectChain); err == nil {
 		t.Fatal("should fail")


### PR DESCRIPTION
Same as https://github.com/0xPolygon/erigon/pull/27/ but on top of `3.1.x`

! NOTE: Not sure if we wanna proceed with 3.1.x, because also VeBlop changes are missing.
In case, this is the PR, which contains way more changes due to the drift of the upstream version compared to `3.0` and `main`

In this PR, we implement the canonical inclusion of state-sync txs in block bodies, as per relative PIP.
This PR reflects the Erigon's changes for this PR in bor:
- https://github.com/0xPolygon/bor/pull/1726

The PR introduces a new typed system transaction, which is included to blocks that execute StateSync events. 
Such txs have zero gas/fees and does not run EVM code, but anchors all StateSync outcomes into the canonical transaction/receipt set. This results in inclusion of such txs into transactionsRoot, receiptsRoot, and logsBloom.

The changes requires a hard fork.

Test worked when enabling StateSync HF from block 0 with the following kurtosis configs
- parameters:
```
polygon_pos_package:
  participants:
    - kind: validator
      cl_type: heimdall-v2
      cl_image: 0xpolygon/heimdall-v2:0.3.1
      el_type: erigon
      el_image: 0xpolygon/erigon:v3.0.18-test
      count: 4
    - kind: rpc
      cl_type: heimdall-v2
      cl_image: 0xpolygon/heimdall-v2:0.3.1
      el_type: erigon
      el_image: 0xpolygon/erigon:v3.0.18-test
      count: 2
  additional_services:
    - test_runner
  ```
 - erigon genesis
 ```
 {
  "config": {
    ...
    },
    "bor": {
      "agraBlock": 0,
      "napoliBlock": 0,
      "jaipurBlock": 0,
      "delhiBlock": 0,
      "indoreBlock": 0,
      "ahmedabadBlock": 0,
      "bhilaiBlock": 0,
      "stateSyncBlock": 0,
      ...
}
```
Receipt was successfully received
<img width="668" height="495" alt="image" src="https://github.com/user-attachments/assets/810417aa-b4d1-4583-8e6b-58cb06392b78" />
