### PR TITLE
rpc: fix GetBlockReceipts

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -527,13 +527,27 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.Block
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
+
+	numTxs := len(block.Transactions())
 	result := make([]map[string]interface{}, 0, len(receipts))
+
 	for _, receipt := range receipts {
-		txn := block.Transactions()[receipt.TransactionIndex]
-		result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, true))
+		// State-sync receipts' TransactionIndex is equal to numTxs.
+		if int(receipt.TransactionIndex) == numTxs {
+			// This is a state-sync transaction receipt.
+			result = append(result, ethutils.MarshalReceipt(receipt, bortypes.NewBorTransaction(), chainConfig, block.HeaderNoCopy(), receipt.TxHash, false, true))
+		} else {
+			// This is a normal transaction receipt.
+			txn := block.Transactions()[receipt.TransactionIndex]
+			result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, true))
+		}
 	}
 
-	if chainConfig.Bor != nil {
+	// TODO: Change Rio to the actual hard fork.
+	// Rio fork (or later) includes state-sync receipts in block execution.
+	// For blocks >= Rio: receipts already include the state-sync receipts.
+	// For blocks < Rio: old cached data doesn't include the state-sync receipts, generate on-the-fly.
+	if chainConfig.Bor != nil && !chainConfig.Bor.IsRio(blockNum) && len(receipts) == numTxs {
 		events, err := api.bridgeReader.Events(ctx, block.Hash(), blockNum)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

If a block only had state sync transactions, the `eth_getBlockReceipts` was crashing with the following error:
```bash
[EROR] [10-14|08:46:23.860] RPC method eth_getBlockReceipts crashed: runtime error: index out of range [0] with length 0
[service.go:222 panic.go:792 panic.go:121 eth_receipts.go:532 value.go:584 value.go:368 service.go:227 handler.go:532 handler.go:482 handler.go:420 handler.go:240 handler.go:333 asm_arm64.s:1223]
```
These changes fix the above error as well, and after the hard fork, we don't need to generate state-sync receipts because they will always be included in the `receipts`.