### PR TITLE
polygon/sync: announce blocks/hashes for blocks received via hash announcements

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -413,7 +413,7 @@ func (s *Sync) applyNewBlockChainOnTip(ctx context.Context, blockChain []*types.
 		return err
 	}
 
-	if source == EventSourceP2PNewBlock {
+	if source == EventSourceP2PNewBlock || source == EventSourceP2PNewBlockHashes {
 		// https://github.com/ethereum/devp2p/blob/master/caps/eth.md#block-propagation
 		// devp2p spec: After the header validity check, the client imports the block into its local chain by executing
 		// all transactions contained in the block, computing the block's 'post state'. The block's state-root hash


### PR DESCRIPTION
A sync issue was recently discovered on a devnet where a bor node was unable to sync with only erigon nodes as it's peers. On further debugging, it turns out that erigon in some cases doesn't announce new blocks or block hashes. 

When processing a block, the source of that block is also passed along. If the source is `EventSourceP2PNewBlock` i.e. block received directly via p2p, that block was further announced (normal block announcement to sqrt(peers) and hash announcement to all peers later). But if erigon receives an announcement of a new block hash (instead of full block), it marks the source as `EventSourceP2PNewBlockHashes`, fetches the block and processes it. Blocks from this source aren't propagated further which seems incorrect. 

This PR fixes that and also sends the block further to peers. This changes was tested on the devnet and it fixed the syncing issue for bor (with only erigon peers). 