### PR TITLE
rpc/jsonrpc, txnprovider: state-sync txn handling over rpc post HF

### DIFF
--- a/rpc/jsonrpc/eth_block.go
+++ b/rpc/jsonrpc/eth_block.go
@@ -229,6 +229,8 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 	}
 	var borTx types.Transaction
 	var borTxHash common.Hash
+	// Bor transactions are included in block body post state-sync HF. Only fetch them
+	// for pre hard fork blocks.
 	if chainConfig.Bor != nil && !chainConfig.Bor.IsStateSync(b.NumberU64()) {
 		possibleBorTxnHash := bortypes.ComputeBorTxHash(b.NumberU64(), b.Hash())
 		_, ok, err := api.bridgeReader.EventTxnLookup(ctx, possibleBorTxnHash)
@@ -288,7 +290,9 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 	}
 	var borTx types.Transaction
 	var borTxHash common.Hash
-	if chainConfig.Bor != nil {
+	// Bor transactions are included in block body post state-sync HF. Only fetch them
+	// for pre hard fork blocks.
+	if chainConfig.Bor != nil && !chainConfig.Bor.IsStateSync(number) {
 		possibleBorTxnHash := bortypes.ComputeBorTxHash(block.NumberU64(), block.Hash())
 		_, ok, err := api.bridgeReader.EventTxnLookup(ctx, possibleBorTxnHash)
 		if err != nil {
@@ -357,7 +361,9 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 		return nil, err
 	}
 
-	if chainConfig.Bor != nil {
+	// Bor transactions are included in block body post state-sync HF. Only fetch them
+	// for pre hard fork blocks.
+	if chainConfig.Bor != nil && !chainConfig.Bor.IsStateSync(blockNum) {
 		borStateSyncTxHash := bortypes.ComputeBorTxHash(blockNum, blockHash)
 
 		_, ok, err := api.bridgeReader.EventTxnLookup(ctx, borStateSyncTxHash)
@@ -399,7 +405,9 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 		return nil, err
 	}
 
-	if chainConfig.Bor != nil {
+	// Bor transactions are included in block body post state-sync HF. Only fetch them
+	// for pre hard fork blocks.
+	if chainConfig.Bor != nil && !chainConfig.Bor.IsStateSync(blockNum) {
 		borStateSyncTxHash := bortypes.ComputeBorTxHash(blockNum, blockHash)
 
 		_, ok, err := api.bridgeReader.EventTxnLookup(ctx, borStateSyncTxHash)

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -286,6 +286,12 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 						return nil, err
 					}
 				}
+
+				block, err := api._blockReader.BlockByHash(ctx, tx, header.Hash())
+				if err != nil {
+					return nil, err
+				}
+
 				// check for state sync event logs
 				events, err := api.bridgeReader.Events(ctx, header.Hash(), blockNum)
 				if err != nil {
@@ -296,7 +302,16 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 					continue
 				}
 
-				borLogs, err := api.borReceiptGenerator.GenerateBorLogs(ctx, events, api._txNumReader, tx, header, chainConfig, txIndex, txNum)
+				// Post HF, calculate the hash directly from txn instead of deriving it from block number and hash
+				var txHash common.Hash
+				if chainConfig.Bor.IsStateSync(block.NumberU64()) {
+					borTx := block.Transactions()[len(block.Transactions())-1]
+					txHash = borTx.Hash()
+				} else {
+					txHash = bortypes.ComputeBorTxHash(block.NumberU64(), block.Hash())
+				}
+
+				borLogs, err := api.borReceiptGenerator.GenerateBorLogs(ctx, events, api._txNumReader, tx, header, chainConfig, txHash, txIndex, txNum)
 				if err != nil {
 					return logs, err
 				}
@@ -456,7 +471,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		return nil, err
 	}
 
-	if isBorStateSyncTx {
+	generateBorReceipt := func(txn types.Transaction) (map[string]interface{}, error) {
 		block, err := api.blockByNumberWithSenders(ctx, tx, blockNum)
 		if err != nil {
 			return nil, err
@@ -479,7 +494,12 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 			return nil, err
 		}
 
-		return ethutils.MarshalReceipt(borReceipt, bortypes.NewBorTransaction(), chainConfig, block.HeaderNoCopy(), txnHash, false, false), nil
+		return ethutils.MarshalReceipt(borReceipt, txn, chainConfig, block.HeaderNoCopy(), txnHash, false, true), nil
+	}
+
+	// This case covers state-sync txs before HF as they're not available in the txn lookup
+	if isBorStateSyncTx {
+		return generateBorReceipt(bortypes.NewBorTransaction())
 	}
 
 	var txnIndex = int(txNum - txNumMin - 1)
@@ -487,6 +507,12 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 	txn, err := api._blockReader.TxnByIdxInBlock(ctx, tx, header.Number.Uint64(), txnIndex)
 	if err != nil {
 		return nil, err
+	}
+
+	// This case covers state-sync txs post HF as they're available in the txn lookup so we can
+	// use the actual state-sync tx type to generate receipt.
+	if txn.Type() == types.StateSyncTxType {
+		return generateBorReceipt(txn)
 	}
 
 	receipt, err := api.getReceipt(ctx, chainConfig, tx, header, txn, txnIndex, txNum)
@@ -533,20 +559,30 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.Block
 		result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, true))
 	}
 
-	if chainConfig.Bor != nil {
-		events, err := api.bridgeReader.Events(ctx, block.Hash(), blockNum)
+	if chainConfig.Bor == nil {
+		return result, nil
+	}
+
+	var borTx types.Transaction = bortypes.NewBorTransaction()
+	if chainConfig.Bor.IsStateSync(blockNum) && len(receipts)+1 == len(block.Transactions()) {
+		borTx = block.Transactions()[len(block.Transactions())-1]
+		if borTx.Type() != types.StateSyncTxType {
+			return result, nil
+		}
+	}
+
+	events, err := api.bridgeReader.Events(ctx, block.Hash(), blockNum)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(events) != 0 {
+		borReceipt, err := api.borReceiptGenerator.GenerateBorReceipt(ctx, tx, block, events, chainConfig)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(events) != 0 {
-			borReceipt, err := api.borReceiptGenerator.GenerateBorReceipt(ctx, tx, block, events, chainConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, ethutils.MarshalReceipt(borReceipt, bortypes.NewBorTransaction(), chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false, true))
-		}
+		result = append(result, ethutils.MarshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false, true))
 	}
 
 	return result, nil

--- a/rpc/jsonrpc/eth_txs.go
+++ b/rpc/jsonrpc/eth_txs.go
@@ -204,7 +204,16 @@ func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, block
 		return nil, nil // not error, see https://github.com/erigontech/erigon/issues/1645
 	}
 
+	// Bor transactions are part of block body post state-sync HF
 	txs := block.Transactions()
+	if chainConfig.Bor != nil && chainConfig.Bor.IsStateSync(block.NumberU64()) {
+		if uint64(txIndex) >= uint64(len(txs)) {
+			return nil, nil // not error
+		}
+		return ethapi.NewRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
+	}
+
+	// Handle pre-HF blocks
 	if uint64(txIndex) > uint64(len(txs)) {
 		return nil, nil // not error
 	} else if uint64(txIndex) == uint64(len(txs)) {
@@ -276,7 +285,16 @@ func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blo
 		return nil, nil // not error, see https://github.com/erigontech/erigon/issues/1645
 	}
 
+	// Bor transactions are part of block body post state-sync HF
 	txs := block.Transactions()
+	if chainConfig.Bor != nil && chainConfig.Bor.IsStateSync(block.NumberU64()) {
+		if uint64(txIndex) >= uint64(len(txs)) {
+			return nil, nil // not error
+		}
+		return ethapi.NewRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
+	}
+
+	// Handle pre-HF blocks
 	if uint64(txIndex) > uint64(len(txs)) {
 		return nil, nil // not error
 	} else if uint64(txIndex) == uint64(len(txs)) {

--- a/rpc/jsonrpc/receipts/bor_receipts_generator.go
+++ b/rpc/jsonrpc/receipts/bor_receipts_generator.go
@@ -2,6 +2,7 @@ package receipts
 
 import (
 	"context"
+	"math/big"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 
@@ -48,8 +49,14 @@ func (g *BorGenerator) GenerateBorReceipt(ctx context.Context, tx kv.TemporalTx,
 		return receipt, nil
 	}
 
+	// Post state-sync HF, state-sync txn is part of block body so calculate index accordingly
+	txIndex := len(block.Transactions())
+	if chainConfig.Bor.IsStateSync(block.NumberU64()) {
+		txIndex = len(block.Transactions()) - 1
+	}
+
 	txNumsReader := g.blockReader.TxnumReader(ctx)
-	ibs, blockContext, _, _, _, err := transactions.ComputeBlockContext(ctx, g.engine, block.HeaderNoCopy(), chainConfig, g.blockReader, txNumsReader, tx, len(block.Transactions())) // we want to get the state at the end of the block
+	ibs, blockContext, _, _, _, err := transactions.ComputeBlockContext(ctx, g.engine, block.HeaderNoCopy(), chainConfig, g.blockReader, txNumsReader, tx, txIndex) // we want to get the state at the end of the block
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +74,16 @@ func (g *BorGenerator) GenerateBorReceipt(ctx context.Context, tx kv.TemporalTx,
 	gp := new(core.GasPool).AddGas(msgs[0].Gas() * uint64(len(msgs))).AddBlobGas(msgs[0].BlobGas() * uint64(len(msgs)))
 	evm := vm.NewEVM(blockContext, evmtypes.TxContext{}, ibs, chainConfig, vm.Config{})
 
-	receipt, err := applyBorTransaction(msgs, evm, gp, ibs, block, cumGasUsedInLastBlock, uint(logIdxAfterTx), rawtemporaldb.ReceiptStoresFirstLogIdx(tx))
+	// Post HF, calculate the hash directly from txn instead of deriving it from block number and hash
+	var txHash common.Hash
+	if chainConfig.Bor.IsStateSync(block.NumberU64()) {
+		borTx := block.Transactions()[len(block.Transactions())-1]
+		txHash = borTx.Hash()
+	} else {
+		txHash = bortypes.ComputeBorTxHash(block.NumberU64(), block.Hash())
+	}
+
+	receipt, err := applyBorTransaction(msgs, evm, gp, ibs, block.Number(), block.Hash(), txHash, uint(txIndex), cumGasUsedInLastBlock, uint(logIdxAfterTx), rawtemporaldb.ReceiptStoresFirstLogIdx(tx))
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +92,7 @@ func (g *BorGenerator) GenerateBorReceipt(ctx context.Context, tx kv.TemporalTx,
 	return receipt, nil
 }
 
-func (g *BorGenerator) GenerateBorLogs(ctx context.Context, msgs []*types.Message, txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, header *types.Header, chainConfig *chain.Config, txIndex int, txNum uint64) (types.Logs, error) {
+func (g *BorGenerator) GenerateBorLogs(ctx context.Context, msgs []*types.Message, txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, header *types.Header, chainConfig *chain.Config, txHash common.Hash, txIndex int, txNum uint64) (types.Logs, error) {
 	ibs, blockContext, _, _, _, err := transactions.ComputeBlockContext(ctx, g.engine, header, chainConfig, g.blockReader, txNumsReader, tx, txIndex)
 	if err != nil {
 		return nil, err
@@ -89,10 +105,11 @@ func (g *BorGenerator) GenerateBorLogs(ctx context.Context, msgs []*types.Messag
 
 	gp := new(core.GasPool).AddGas(msgs[0].Gas() * uint64(len(msgs))).AddBlobGas(msgs[0].BlobGas() * uint64(len(msgs)))
 	evm := vm.NewEVM(blockContext, evmtypes.TxContext{}, ibs, chainConfig, vm.Config{})
-	return getBorLogs(msgs, evm, gp, ibs, header.Number.Uint64(), header.Hash(), uint(txIndex), uint(logIdxAfterTx), rawtemporaldb.ReceiptStoresFirstLogIdx(tx))
+
+	return getBorLogs(msgs, evm, gp, ibs, header.Number.Uint64(), header.Hash(), txHash, uint(txIndex), uint(logIdxAfterTx), rawtemporaldb.ReceiptStoresFirstLogIdx(tx))
 }
 
-func getBorLogs(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state.IntraBlockState, blockNum uint64, blockHash common.Hash, txIndex, logIdxAfterTx uint, receiptWithFirstLogIdx bool) (types.Logs, error) {
+func getBorLogs(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state.IntraBlockState, blockNum uint64, blockHash common.Hash, txHash common.Hash, txIndex, logIdxAfterTx uint, receiptWithFirstLogIdx bool) (types.Logs, error) {
 	for _, msg := range msgs {
 		txContext := core.NewEVMTxContext(msg)
 		evm.Reset(txContext, ibs)
@@ -103,7 +120,7 @@ func getBorLogs(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state
 		}
 	}
 
-	receiptLogs := ibs.GetLogs(0, bortypes.ComputeBorTxHash(blockNum, blockHash), blockNum, blockHash)
+	receiptLogs := ibs.GetLogs(0, txHash, blockNum, blockHash)
 
 	// set fields
 	var logIndex uint
@@ -126,21 +143,20 @@ func getBorLogs(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state
 	return receiptLogs, nil
 }
 
-func applyBorTransaction(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state.IntraBlockState, block *types.Block, cumulativeGasUsed uint64, logIdxAfterTx uint, receiptWithFirstLogIdx bool) (*types.Receipt, error) {
-	receiptLogs, err := getBorLogs(msgs, evm, gp, ibs, block.Number().Uint64(), block.Hash(), uint(len(block.Transactions())), logIdxAfterTx, receiptWithFirstLogIdx)
+func applyBorTransaction(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state.IntraBlockState, blockNumber *big.Int, blockHash common.Hash, txHash common.Hash, txIndex uint, cumulativeGasUsed uint64, logIdxAfterTx uint, receiptWithFirstLogIdx bool) (*types.Receipt, error) {
+	receiptLogs, err := getBorLogs(msgs, evm, gp, ibs, blockNumber.Uint64(), blockHash, txHash, txIndex, logIdxAfterTx, receiptWithFirstLogIdx)
 	if err != nil {
 		return nil, err
 	}
 
-	numReceipts := len(block.Transactions())
 	receipt := types.Receipt{
 		Type:              0,
 		CumulativeGasUsed: cumulativeGasUsed,
-		TxHash:            bortypes.ComputeBorTxHash(block.NumberU64(), block.Hash()),
+		TxHash:            txHash,
 		GasUsed:           0,
-		BlockHash:         block.Hash(),
-		BlockNumber:       block.Number(),
-		TransactionIndex:  uint(numReceipts),
+		BlockHash:         blockHash,
+		BlockNumber:       blockNumber,
+		TransactionIndex:  txIndex,
 		Logs:              receiptLogs,
 		Status:            types.ReceiptStatusSuccessful,
 	}

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -149,6 +149,11 @@ func (g *Generator) addToCacheReceipt(hash common.Hash, receipt *types.Receipt) 
 }
 
 func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.TemporalTx, header *types.Header, txn types.Transaction, index int, txNum uint64) (*types.Receipt, error) {
+	// Use bor receipt generator for state-sync txns, exit early
+	if txn.Type() == types.StateSyncTxType {
+		return nil, fmt.Errorf("ReceiptGen.GetReceipt: txn is a state-sync transaction")
+	}
+
 	blockHash := header.Hash()
 	blockNum := header.Number.Uint64()
 	txnHash := txn.Hash()
@@ -282,7 +287,13 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 
 	//if can find in DB - then don't need store in `receiptsCache` - because DB it's already kind-of cache (small, mmaped, hot file)
 	var receiptsFromDB types.Receipts
-	receipts := make(types.Receipts, len(block.Transactions()))
+	var txCount = len(block.Transactions())
+	if txCount > 0 {
+		if block.Transactions()[txCount-1].Type() == types.StateSyncTxType {
+			txCount-- // exclude state-sync tx
+		}
+	}
+	receipts := make(types.Receipts, txCount)
 	defer func() {
 		if dbg.Enabled(ctx) {
 			log.Info("[dbg] ReceiptGenerator.GetReceipts",
@@ -328,6 +339,11 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
+		}
+
+		// skip state-sync transaction
+		if txn.Type() == types.StateSyncTxType {
+			continue
 		}
 
 		evm := core.CreateEVM(cfg, core.GetHashFn(genEnv.header, genEnv.getHeader), g.engine, nil, genEnv.ibs, genEnv.header, vmCfg)

--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -43,11 +43,12 @@ import (
 
 const (
 	LegacyTxnType     byte = 0
-	AccessListTxnType byte = 1 // EIP-2930
-	DynamicFeeTxnType byte = 2 // EIP-1559
-	BlobTxnType       byte = 3 // EIP-4844
-	SetCodeTxnType    byte = 4 // EIP-7702
-	AATxnType         byte = 5 // RIP-7560
+	AccessListTxnType byte = 1   // EIP-2930
+	DynamicFeeTxnType byte = 2   // EIP-1559
+	BlobTxnType       byte = 3   // EIP-4844
+	SetCodeTxnType    byte = 4   // EIP-7702
+	AATxnType         byte = 5   // RIP-7560
+	StateSyncTxType   byte = 127 // PIP-74
 )
 
 var ErrParseTxn = fmt.Errorf("%w transaction", rlp.ErrParse)
@@ -158,7 +159,7 @@ func (ctx *TxnParseContext) ParseTransaction(payload []byte, pos int, slot *TxnS
 	// If it is non-legacy transaction, the transaction type follows, and then the list
 	if !legacy {
 		slot.Type = payload[p]
-		if slot.Type > AATxnType {
+		if slot.Type > AATxnType && slot.Type != StateSyncTxType {
 			return 0, fmt.Errorf("%w: unknown transaction type: %d", ErrParseTxn, slot.Type)
 		}
 		p++


### PR DESCRIPTION
RPC method implementations handle state-sync transaction separately. The state-sync HF, which includes state-sync transactions in the block body, changes some assumptions taken for some rpc methods. This PR handles that. 