### PR TITLE
polygon/bor: use unmarshal for event record instead of rlp decode

### DIFF
--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -56,6 +56,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	"github.com/erigontech/erigon/polygon/bor/statefull"
+	"github.com/erigontech/erigon/polygon/bridge"
 	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/turbo/services"
@@ -1308,9 +1309,9 @@ func (c *Bor) CommitStates(
 			return nil, err
 		}
 
-		var ev types.StateSyncData
-		if err := rlp.DecodeBytes(event.Data(), &ev); err != nil {
-			log.Error("error while decoding state sync data", "err", err)
+		var ev bridge.EventRecordWithTime
+		if err := ev.UnmarshallBytes(event.Data()); err != nil {
+			log.Error("error while unmarshaling state sync data", "err", err)
 			continue // Not a state-sync event, skip
 		}
 

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1308,6 +1308,10 @@ func (c *Bor) CommitStates(
 		if _, err := syscall(*event.To(), event.Data()); err != nil {
 			return nil, err
 		}
+		// Can be empty in tests
+		if len(event.Data()) == 0 {
+			continue
+		}
 
 		var ev bridge.EventRecordWithTime
 		if err := ev.UnmarshallBytes(event.Data()); err != nil {


### PR DESCRIPTION
The bridge events stored in db are marshalled version of a different type `bridge.EventRecordWithTime` and not `types.StateSyncData`. We can use the unmarshal method instead of rlp decode. 

This only applies to `FinalizeAndAssemble` as we ignore the result in `Finalize`.