### PR TITLE
Updating package names for consistency

### DIFF
--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Upload artifact amd64.deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  ## v4.6.2
         with:
-          name: ${{ inputs.application }}_${{ inputs.version }}_amd64.deb
+          name: ${{ inputs.application }}_v${{ inputs.version }}_amd64.deb
           path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_amd64.deb
           retention-days: 5
           compression-level: 0
@@ -114,7 +114,7 @@ jobs:
       - name: Upload artifact amd64.deb.checksum
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  ## v4.6.2
         with:
-          name: ${{ inputs.application }}_${{ inputs.version }}_amd64.deb.checksum
+          name: ${{ inputs.application }}_v${{ inputs.version }}_amd64.deb.checksum
           path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_amd64.deb.checksum
           retention-days: 5
           compression-level: 0
@@ -123,7 +123,7 @@ jobs:
       - name: Upload artifact arm64.deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  ## v4.6.2
         with:
-          name: ${{ inputs.application }}_${{ inputs.version }}_arm64.deb
+          name: ${{ inputs.application }}_v${{ inputs.version }}_arm64.deb
           path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_arm64.deb
           retention-days: 5
           compression-level: 0
@@ -132,7 +132,7 @@ jobs:
       - name: Upload artifact arm64.deb.checksum
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  ## v4.6.2
         with:
-          name: ${{ inputs.application }}_${{ inputs.version }}_arm64.deb.checksum
+          name: ${{ inputs.application }}_v${{ inputs.version }}_arm64.deb.checksum
           path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_arm64.deb.checksum
           retention-days: 5
           compression-level: 0


### PR DESCRIPTION
In the naming of the debian packages, the v is being dropped. I am adding this in so the package names are consistent with the tar archives. Adjusted checksums so they also upload to the updated named artifact

<img width="1541" height="1046" alt="Screenshot 2025-11-03 at 7 47 30 AM" src="https://github.com/user-attachments/assets/fbb1023e-4336-4995-b76d-c891d41c648f" />
