### PR TITLE
eth/tracers/native/prestate: ensure account entry exists before accessing prestateTracer

### DIFF
--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -329,6 +329,9 @@ func (t *prestateTracer) lookupStorage(addr common.Address, key common.Hash) {
 		return
 	}
 
+	// Ensure the account exists before accessing its storage
+	t.lookupAccount(addr)
+
 	if _, ok := t.pre[addr].Storage[key]; ok {
 		return
 	}


### PR DESCRIPTION
This fixes the handler crash while calling `debug_traceBlock` on a block containing state sync transaction post Madhugiri HF.