### PR TITLE
Dandeli HF: modify block gas target calculations

### DIFF
--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/generics"
 	"github.com/erigontech/erigon/execution/chain/params"
+	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
 
 // Config is the core config which determines the blockchain settings.
@@ -140,6 +141,33 @@ var (
 		BerlinBlock:           big.NewInt(0),
 		LondonBlock:           big.NewInt(0),
 		Aura:                  &AuRaConfig{},
+	}
+
+	TestChainBorConfig = &Config{
+		ChainID:               big.NewInt(1337),
+		Consensus:             BorConsensus,
+		HomesteadBlock:        big.NewInt(0),
+		TangerineWhistleBlock: big.NewInt(0),
+		SpuriousDragonBlock:   big.NewInt(0),
+		ByzantiumBlock:        big.NewInt(0),
+		ConstantinopleBlock:   big.NewInt(0),
+		PetersburgBlock:       big.NewInt(0),
+		IstanbulBlock:         big.NewInt(0),
+		MuirGlacierBlock:      big.NewInt(0),
+		BerlinBlock:           big.NewInt(0),
+		LondonBlock:           big.NewInt(0),
+		Bor: &borcfg.BorConfig{
+			JaipurBlock:       big.NewInt(0),
+			DelhiBlock:        big.NewInt(0),
+			IndoreBlock:       big.NewInt(0),
+			AgraBlock:         big.NewInt(0),
+			NapoliBlock:       big.NewInt(0),
+			AhmedabadBlock:    big.NewInt(0),
+			BhilaiBlock:       big.NewInt(0),
+			RioBlock:          big.NewInt(0),
+			MadhugiriBlock:    big.NewInt(0),
+			MadhugiriProBlock: big.NewInt(0),
+		},
 	}
 
 	// AllProtocolChanges contains every protocol change (EIPs) introduced

--- a/execution/chain/params/protocol.go
+++ b/execution/chain/params/protocol.go
@@ -133,6 +133,8 @@ const (
 	BaseFeeChangeDenominatorPostDelhi  = 16         // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
 	BaseFeeChangeDenominatorPostBhilai = 64         // Bounds the amount the base fee can change between blocks post bhilai hard fork for polygon networks.
 	ElasticityMultiplier               = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
+	DefaultTargetGasPercentage         = 50         // Specifies target block gas as percentage of block gas limit for EIP-1559
+	TargetGasPercentagePostDandeli     = 60         // Specifies target block gas as percentage of block gas limit for EIP-1559 after Dandeli hard fork
 	InitialBaseFee                     = 1000000000 // Initial base fee for EIP-1559 blocks.
 
 	MaxCodeSize              = 24576           // Maximum bytecode to permit for a contract

--- a/execution/chain/params/protocol.go
+++ b/execution/chain/params/protocol.go
@@ -134,7 +134,7 @@ const (
 	BaseFeeChangeDenominatorPostBhilai = 64         // Bounds the amount the base fee can change between blocks post bhilai hard fork for polygon networks.
 	ElasticityMultiplier               = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	DefaultTargetGasPercentage         = 50         // Specifies target block gas as percentage of block gas limit for EIP-1559
-	TargetGasPercentagePostDandeli     = 60         // Specifies target block gas as percentage of block gas limit for EIP-1559 after Dandeli hard fork
+	TargetGasPercentagePostDandeli     = 65         // Specifies target block gas as percentage of block gas limit for EIP-1559 after Dandeli hard fork
 	InitialBaseFee                     = 1000000000 // Initial base fee for EIP-1559 blocks.
 
 	MaxCodeSize              = 24576           // Maximum bytecode to permit for a contract

--- a/execution/consensus/misc/eip1559.go
+++ b/execution/consensus/misc/eip1559.go
@@ -109,7 +109,7 @@ func CalcBaseFee(config *chain.Config, parent *types.Header) *big.Int {
 	}
 
 	var (
-		parentGasTarget          = parent.GasLimit / params.ElasticityMultiplier
+		parentGasTarget          = calcParentGasTarget(config.Bor, parent)
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(getBaseFeeChangeDenominator(config.Bor, parent.Number.Uint64()))
 	)
@@ -140,6 +140,18 @@ func CalcBaseFee(config *chain.Config, parent *types.Header) *big.Int {
 			common.Big0,
 		)
 	}
+}
+
+// calcParentGasTarget calculates the target gas based on parent block gas limit. Earlier
+// it was derived by `ElasticityMultiplier` as it had an integer multiplier value. Post
+// dandeli HF, a percentage value will be used to calculate the gas target.
+func calcParentGasTarget(borConfig chain.BorConfig, parent *types.Header) uint64 {
+	if borConfig, ok := borConfig.(*borcfg.BorConfig); ok {
+		if borConfig.IsDandeli(parent.Number.Uint64()) {
+			return parent.GasLimit * params.TargetGasPercentagePostDandeli / 100
+		}
+	}
+	return parent.GasLimit / params.ElasticityMultiplier
 }
 
 func getBaseFeeChangeDenominator(borConfig chain.BorConfig, number uint64) uint64 {

--- a/execution/consensus/misc/eip1559.go
+++ b/execution/consensus/misc/eip1559.go
@@ -109,6 +109,7 @@ func CalcBaseFee(config *chain.Config, parent *types.Header) *big.Int {
 	}
 
 	var (
+		// Modified for bor to derive gas target by percentage instead of using elasticity multiplier post dandeli HF
 		parentGasTarget          = calcParentGasTarget(config.Bor, parent)
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(getBaseFeeChangeDenominator(config.Bor, parent.Number.Uint64()))

--- a/execution/consensus/misc/eip1559_test.go
+++ b/execution/consensus/misc/eip1559_test.go
@@ -158,7 +158,7 @@ func TestCalcParentGasTarget(t *testing.T) {
 			BaseFee:  big.NewInt(params.InitialBaseFee),
 		}
 		gasTarget := calcParentGasTarget(testConfig.Bor, block)
-		expected := block.GasLimit * 6 / 10 // because gas target is 60% of total block gas limit
+		expected := block.GasLimit * params.TargetGasPercentagePostDandeli / 100 // because gas target is derived by this protocol parameter
 		require.Equal(t, expected, gasTarget, "case #1: expected gas target = 60 percent of gas limit")
 
 		block = &types.Header{
@@ -168,7 +168,7 @@ func TestCalcParentGasTarget(t *testing.T) {
 			BaseFee:  big.NewInt(params.InitialBaseFee),
 		}
 		gasTarget = calcParentGasTarget(testConfig.Bor, block)
-		expected = block.GasLimit * 6 / 10 // because gas target is 60% of total block gas limit
+		expected = block.GasLimit * params.TargetGasPercentagePostDandeli / 100 // because gas target is derived by this protocol parameter
 		require.Equal(t, expected, gasTarget, "case #2: expected gas target = 60 percent of gas limit")
 	})
 

--- a/execution/consensus/misc/eip1559_test.go
+++ b/execution/consensus/misc/eip1559_test.go
@@ -20,15 +20,18 @@
 package misc
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/jinzhu/copier"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/params"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
 
 // copyConfig does a _shallow_ copy of a given config. Safe to set new values, but
@@ -43,6 +46,10 @@ func config() *chain.Config {
 	config := copyConfig(chain.TestChainConfig)
 	config.LondonBlock = big.NewInt(5)
 	return config
+}
+
+func borConfig() *chain.Config {
+	return copyConfig(chain.TestChainBorConfig)
 }
 
 // TestBlockGasLimits tests the gasLimit checks for blocks both across
@@ -117,5 +124,221 @@ func TestCalcBaseFee(t *testing.T) {
 		if have, want := CalcBaseFee(config(), parent), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
+	}
+}
+
+func TestCalcParentGasTarget(t *testing.T) {
+	t.Parallel()
+
+	testConfig := borConfig()
+	if borConfig, ok := testConfig.Bor.(*borcfg.BorConfig); ok {
+		borConfig.DandeliBlock = big.NewInt(20)
+	} else {
+		t.Fatalf("Unable to load bor config for test")
+	}
+	defaultGasLimit := uint64(60_000_000)
+
+	t.Run("gas target calculation pre dandeli HF", func(t *testing.T) {
+		block := &types.Header{
+			Number:   big.NewInt(9),
+			GasLimit: defaultGasLimit,
+			GasUsed:  defaultGasLimit / 2,
+			BaseFee:  big.NewInt(params.InitialBaseFee),
+		}
+		gasTarget := calcParentGasTarget(testConfig.Bor, block)
+		expected := block.GasLimit / 2 // because elasticity multiplier is set to 2 by default
+		require.Equal(t, expected, gasTarget, "expected gas target = gaslimit/2")
+	})
+
+	t.Run("gas target calculation post dandeli HF", func(t *testing.T) {
+		block := &types.Header{
+			Number:   big.NewInt(20),
+			GasLimit: defaultGasLimit,
+			GasUsed:  defaultGasLimit / 2,
+			BaseFee:  big.NewInt(params.InitialBaseFee),
+		}
+		gasTarget := calcParentGasTarget(testConfig.Bor, block)
+		expected := block.GasLimit * 6 / 10 // because gas target is 60% of total block gas limit
+		require.Equal(t, expected, gasTarget, "case #1: expected gas target = 60 percent of gas limit")
+
+		block = &types.Header{
+			Number:   big.NewInt(21),
+			GasLimit: defaultGasLimit,
+			GasUsed:  defaultGasLimit / 2,
+			BaseFee:  big.NewInt(params.InitialBaseFee),
+		}
+		gasTarget = calcParentGasTarget(testConfig.Bor, block)
+		expected = block.GasLimit * 6 / 10 // because gas target is 60% of total block gas limit
+		require.Equal(t, expected, gasTarget, "case #2: expected gas target = 60 percent of gas limit")
+	})
+
+	t.Run("nil bor config", func(t *testing.T) {
+		testConfig.Bor = nil
+		block := &types.Header{
+			Number:   big.NewInt(21),
+			GasLimit: defaultGasLimit,
+			GasUsed:  defaultGasLimit / 2,
+			BaseFee:  big.NewInt(params.InitialBaseFee),
+		}
+		gasTarget := calcParentGasTarget(testConfig.Bor, block)
+		expected := block.GasLimit / 2 // because elasticity multiplier is set to 2 by default
+		require.Equal(t, expected, gasTarget, "expected gas target = gaslimit/2 when bor config is nil")
+	})
+}
+
+// simpleBaseFeeCalculator contains an overly simplified logic of base fee calculations useful for generating
+// expected values in test cases. It assumes all blocks are post-bhilai HF.
+func simpleBaseFeeCalculator(initialBaseFee int64, gasLimit, gasUsed uint64, targetGasPercentage uint64) uint64 {
+	initial := big.NewInt(initialBaseFee)
+	val := big.NewInt(1)
+	val.Mul(val, initial)
+
+	// Assuming tests are running post bhilai
+	bfd := int64(params.BaseFeeChangeDenominatorPostBhilai)
+
+	// Define a target gas based on given percentage
+	target := gasLimit * targetGasPercentage / 100
+	if gasUsed == target {
+		return initial.Uint64()
+	}
+
+	// follow the simple formula to get the new base fee:
+	// base fee = initialBaseFee +/- (initialBaseFee * gasUsedDelta / gasTarget / baseFeeChangeDenominator)
+
+	var delta int64
+	if gasUsed > target {
+		delta = int64(gasUsed - target)
+	} else {
+		delta = int64(target - gasUsed)
+	}
+
+	val.Mul(val, big.NewInt(delta))
+	val.Div(val, big.NewInt(int64(bfd)))
+	val.Div(val, big.NewInt(int64(target)))
+
+	if gasUsed > target {
+		return initial.Add(initial, val).Uint64()
+	} else {
+		return initial.Sub(initial, val).Uint64()
+	}
+}
+
+func TestCalcBaseFeeDandeli(t *testing.T) {
+	t.Parallel()
+
+	testConfig := borConfig()
+	if borConfig, ok := testConfig.Bor.(*borcfg.BorConfig); ok {
+		borConfig.DandeliBlock = big.NewInt(20)
+	} else {
+		t.Fatalf("Unable to load bor config for test")
+	}
+
+	// Case 1: Create pre-dandeli cases where HF is defined in future. Validate
+	// base fee calculations before HF kicks in. Base fee should be calculated
+	// based on default elasticity multiplier.
+	tests := []struct {
+		name            string
+		parentBaseFee   int64
+		parentGasLimit  uint64
+		parentGasUsed   uint64
+		expectedBaseFee uint64
+	}{
+		{"usage == target", params.InitialBaseFee, 60_000_000, 30_000_000, params.InitialBaseFee},
+		{"usage below target #1", params.InitialBaseFee, 60_000_000, 20_000_000, 994791667},
+		{"usage below target #2", params.InitialBaseFee, 60_000_000, 10_000_000, 989583334},
+		{"usage above target #1", params.InitialBaseFee, 60_000_000, 40_000_000, 1005208333},
+		{"usage above target #2", params.InitialBaseFee, 60_000_000, 50_000_000, 1010416666},
+		{"usage full", params.InitialBaseFee, 60_000_000, 60_000_000, 1015625000},
+		{"usage 0", params.InitialBaseFee, 60_000_000, 0, 984375000},
+	}
+	for _, test := range tests {
+		block := &types.Header{
+			Number:   big.NewInt(8),
+			GasLimit: test.parentGasLimit,
+			GasUsed:  test.parentGasUsed,
+			BaseFee:  big.NewInt(test.parentBaseFee),
+		}
+		baseFee := CalcBaseFee(testConfig, block).Uint64()
+		expectedBaseFee := simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, 50)
+		require.Equal(
+			t,
+			expectedBaseFee,
+			baseFee,
+			fmt.Sprintf("pre-dandeli base fee mismatch with expected value, test: %s, got: %d, want: %d", test.name, baseFee, expectedBaseFee),
+		)
+		// Also check with manually calculated base fee
+		require.Equal(
+			t,
+			test.expectedBaseFee,
+			baseFee,
+			fmt.Sprintf("pre-dandeli base fee mismatch with manually calculated value, test: %s, got: %d, want: %d", test.name, baseFee, expectedBaseFee),
+		)
+	}
+
+	// Case 2: Create post-dandeli cases where HF has kicked in. Validate base fee changes
+	// based on the newly introduced protocol param: TargetGasPrecentage. Target gas limit
+	// should be calculated based on this percentage value out of total gas limit. Base
+	// fee should be changed accordingly.
+	tests = []struct {
+		name            string
+		parentBaseFee   int64
+		parentGasLimit  uint64
+		parentGasUsed   uint64
+		expectedBaseFee uint64
+	}{
+		{"usage == target (60%)", params.InitialBaseFee, 60_000_000, 36_000_000, params.InitialBaseFee},
+		{"usage below target #1", params.InitialBaseFee, 60_000_000, 30_000_000, 997395834},
+		{"usage below target #2", params.InitialBaseFee, 60_000_000, 10_000_000, 988715278},
+		{"usage above target #1", params.InitialBaseFee, 60_000_000, 40_000_000, 1001736111},
+		{"usage above target #2", params.InitialBaseFee, 60_000_000, 50_000_000, 1006076388},
+		{"usage full", params.InitialBaseFee, 60_000_000, 60_000_000, 1010416666},
+		{"usage 0", params.InitialBaseFee, 60_000_000, 0, 984375000},
+	}
+	for _, test := range tests {
+		// Post-dandeli block #1
+		block := &types.Header{
+			Number:   big.NewInt(20),
+			GasLimit: test.parentGasLimit,
+			GasUsed:  test.parentGasUsed,
+			BaseFee:  big.NewInt(test.parentBaseFee),
+		}
+		baseFee := CalcBaseFee(testConfig, block).Uint64()
+		expectedBaseFee := simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, 60)
+		require.Equal(
+			t,
+			expectedBaseFee,
+			baseFee,
+			fmt.Sprintf("post-dandeli #1: base fee mismatch with expected value, test: %s, got: %d, want: %d", test.name, baseFee, expectedBaseFee),
+		)
+		// Also check with manually calculated base fee
+		require.Equal(
+			t,
+			test.expectedBaseFee,
+			baseFee,
+			fmt.Sprintf("post-dandeli #1: base fee mismatch with manually calculated value, test: %s, got: %d, want: %d", test.name, baseFee, expectedBaseFee),
+		)
+
+		// Post-dandeli block #2
+		block = &types.Header{
+			Number:   big.NewInt(21),
+			GasLimit: test.parentGasLimit,
+			GasUsed:  test.parentGasUsed,
+			BaseFee:  big.NewInt(test.parentBaseFee),
+		}
+		baseFee = CalcBaseFee(testConfig, block).Uint64()
+		expectedBaseFee = simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, 60)
+		require.Equal(
+			t,
+			expectedBaseFee,
+			baseFee,
+			fmt.Sprintf("post-dandeli #2: base fee mismatch with expected value, test: %s, got: %d, want: %d", test.name, baseFee, expectedBaseFee),
+		)
+		// Also check with manually calculated base fee
+		require.Equal(
+			t,
+			test.expectedBaseFee,
+			baseFee,
+			fmt.Sprintf("post-dandeli #2: base fee mismatch with manually calculated value, test: %s, got: %d, want: %d", test.name, baseFee, expectedBaseFee),
+		)
 	}
 }

--- a/execution/consensus/misc/eip1559_test.go
+++ b/execution/consensus/misc/eip1559_test.go
@@ -259,7 +259,7 @@ func TestCalcBaseFeeDandeli(t *testing.T) {
 			BaseFee:  big.NewInt(test.parentBaseFee),
 		}
 		baseFee := CalcBaseFee(testConfig, block).Uint64()
-		expectedBaseFee := simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, 50)
+		expectedBaseFee := simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, params.DefaultTargetGasPercentage)
 		require.Equal(
 			t,
 			expectedBaseFee,
@@ -286,12 +286,12 @@ func TestCalcBaseFeeDandeli(t *testing.T) {
 		parentGasUsed   uint64
 		expectedBaseFee uint64
 	}{
-		{"usage == target (60%)", params.InitialBaseFee, 60_000_000, 36_000_000, params.InitialBaseFee},
-		{"usage below target #1", params.InitialBaseFee, 60_000_000, 30_000_000, 997395834},
-		{"usage below target #2", params.InitialBaseFee, 60_000_000, 10_000_000, 988715278},
-		{"usage above target #1", params.InitialBaseFee, 60_000_000, 40_000_000, 1001736111},
-		{"usage above target #2", params.InitialBaseFee, 60_000_000, 50_000_000, 1006076388},
-		{"usage full", params.InitialBaseFee, 60_000_000, 60_000_000, 1010416666},
+		{"usage == target (65%)", params.InitialBaseFee, 60_000_000, 39_000_000, params.InitialBaseFee},
+		{"usage below target #1", params.InitialBaseFee, 60_000_000, 30_000_000, 996394231},
+		{"usage below target #2", params.InitialBaseFee, 60_000_000, 10_000_000, 988381411},
+		{"usage above target #1", params.InitialBaseFee, 60_000_000, 40_000_000, 1000400641},
+		{"usage above target #2", params.InitialBaseFee, 60_000_000, 50_000_000, 1004407051},
+		{"usage full", params.InitialBaseFee, 60_000_000, 60_000_000, 1008413461},
 		{"usage 0", params.InitialBaseFee, 60_000_000, 0, 984375000},
 	}
 	for _, test := range tests {
@@ -303,7 +303,7 @@ func TestCalcBaseFeeDandeli(t *testing.T) {
 			BaseFee:  big.NewInt(test.parentBaseFee),
 		}
 		baseFee := CalcBaseFee(testConfig, block).Uint64()
-		expectedBaseFee := simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, 60)
+		expectedBaseFee := simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, params.TargetGasPercentagePostDandeli)
 		require.Equal(
 			t,
 			expectedBaseFee,
@@ -326,7 +326,7 @@ func TestCalcBaseFeeDandeli(t *testing.T) {
 			BaseFee:  big.NewInt(test.parentBaseFee),
 		}
 		baseFee = CalcBaseFee(testConfig, block).Uint64()
-		expectedBaseFee = simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, 60)
+		expectedBaseFee = simpleBaseFeeCalculator(block.BaseFee.Int64(), block.GasLimit, block.GasUsed, params.TargetGasPercentagePostDandeli)
 		require.Equal(
 			t,
 			expectedBaseFee,

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon-lib/common/generics"
 )
 
 // BorConfig is the consensus engine configs for bor-based sealing.
@@ -47,6 +47,7 @@ type BorConfig struct {
 	RioBlock          *big.Int `json:"rioBlock"`          // Rio switch block (nil = no fork, 0 = already on Rio)
 	MadhugiriBlock    *big.Int `json:"madhugiriBlock"`    // Madhugiri switch block (nil = no fork, 0 = already on Madhugiri)
 	MadhugiriProBlock *big.Int `json:"madhugiriProBlock"` // MadhugiriPro switch block (nil = no fork, 0 = already on MadhugiriPro)
+	DandeliBlock      *big.Int `json:"dandeliBlock"`      // Dandeli switch block (nil = no fork, 0 = already on Dandeli)
 
 	StateSyncConfirmationDelay map[string]uint64         `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 	Coinbase                   map[string]common.Address `json:"coinbase"`                   // coinbase address
@@ -59,7 +60,7 @@ func (c *BorConfig) String() string {
 }
 
 func (c *BorConfig) CalculateProducerDelay(number uint64) uint64 {
-	return chain.ConfigValueLookup(common.ParseMapKeysIntoUint64(c.ProducerDelay), number)
+	return ConfigValueLookup(common.ParseMapKeysIntoUint64(c.ProducerDelay), number)
 }
 
 func (c *BorConfig) IsSprintStart(number uint64) bool {
@@ -117,11 +118,11 @@ func (c *BorConfig) CalculateSprintNumber(number uint64) uint64 {
 }
 
 func (c *BorConfig) CalculateBackupMultiplier(number uint64) uint64 {
-	return chain.ConfigValueLookup(common.ParseMapKeysIntoUint64(c.BackupMultiplier), number)
+	return ConfigValueLookup(common.ParseMapKeysIntoUint64(c.BackupMultiplier), number)
 }
 
 func (c *BorConfig) CalculatePeriod(number uint64) uint64 {
-	return chain.ConfigValueLookup(common.ParseMapKeysIntoUint64(c.Period), number)
+	return ConfigValueLookup(common.ParseMapKeysIntoUint64(c.Period), number)
 }
 
 // isForked returns whether a fork scheduled at block s is active at the given head block.
@@ -205,13 +206,17 @@ func (c *BorConfig) GetMadhugiriProBlock() *big.Int {
 	return c.MadhugiriProBlock
 }
 
+func (c *BorConfig) IsDandeli(number uint64) bool {
+	return isForked(c.DandeliBlock, number)
+}
+
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {
-	return chain.ConfigValueLookup(common.ParseMapKeysIntoUint64(c.StateSyncConfirmationDelay), number)
+	return ConfigValueLookup(common.ParseMapKeysIntoUint64(c.StateSyncConfirmationDelay), number)
 }
 
 func (c *BorConfig) CalculateCoinbase(number uint64) common.Address {
 	if c.Coinbase != nil {
-		return chain.ConfigValueLookup(common.ParseMapKeysIntoUint64(c.Coinbase), number)
+		return ConfigValueLookup(common.ParseMapKeysIntoUint64(c.Coinbase), number)
 	} else {
 		return common.Address{}
 	}
@@ -252,4 +257,25 @@ func asSprints(configSprints map[string]uint64) sprints {
 	sort.Sort(sprints)
 
 	return sprints
+}
+
+// Duplicate of execution/chain's ConfigValueLookup function to avoid circular import
+
+// Looks up a config value as of a given block number (or time).
+// The assumption here is that config is a càdlàg map of starting_from_block -> value.
+// For example, config of {5: "A", 10: "B", 20: "C"}
+// means that the config value is "A" for blocks 5–9,
+// "B" for blocks 10–19, and "C" for block 20 and above.
+// For blocks 0–4 an empty string will be returned.
+func ConfigValueLookup[T any](field map[uint64]T, number uint64) T {
+	keys := common.SortedKeys(field)
+	if number < keys[0] {
+		return generics.Zero[T]()
+	}
+	for i := 0; i < len(keys)-1; i++ {
+		if number >= keys[i] && number < keys[i+1] {
+			return field[keys[i]]
+		}
+	}
+	return field[keys[len(keys)-1]]
 }

--- a/polygon/chain/chainspecs/amoy.json
+++ b/polygon/chain/chainspecs/amoy.json
@@ -48,6 +48,7 @@
       "rioBlock": 26272256,
       "madhugiriBlock": 28899616,
       "madhugiriProBlock": 29287400,
+      "dandeliBlock": 31890000,
       "blockAlloc": {
         "11865856": {
           "0000000000000000000000000000000000001001": {


### PR DESCRIPTION
Instead of deriving block gas target to calculate base fee for eip 1559 using elasticity multiplier, this HF introduces a percentage denoting the percent of gas target to choose from total block gas limit. It acts as an inverse of elasticity multiplier in percent terms. E.g. current default elasticity multiplier is 2 which translates to 50% of total block limit as gas target. To address the gas spikes, this is modified to 66% which means gas target would be 66% of block gas limit. This makes the base fee increase bit slower that earlier during surge in chain activity.