### PR TITLE
polygon/sync: fix goroutine leak in batch processing

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -521,6 +521,7 @@ func (s *Sync) applyNewBlockBatchOnTip(ctx context.Context, event EventNewBlockB
 				return ctx.Err()
 			case event.Processed <- err:
 			}
+			err = nil
 		}
 		return nil
 	}


### PR DESCRIPTION
This change prevents a second send on EventNewBlockBatch.Processed in applyNewBlockBatchOnTip. It resets the local error after explicitly reporting known-bad block cases so the deferred handler does not attempt to send again. This avoids a potential goroutine block/leak in the backward download flow waiting on processed signals.