### PR TITLE
feat: configurable pruning limits + span-rotation improves

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1002,7 +1002,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 	furiousPrune := timeout > 5*time.Hour
 	aggressivePrune := !furiousPrune && timeout >= 1*time.Minute
 
-	var pruneLimit uint64 = 100
+	var pruneLimit uint64 = uint64(dbg.EnvInt("ERIGON_PRUNE_LIMIT", 100))
 	if furiousPrune {
 		pruneLimit = 1_000_000
 	}

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -763,7 +763,7 @@ Loop:
 				timeStart := time.Now()
 
 				// allow greedy prune on non-chain-tip
-				pruneTimeout := 250 * time.Millisecond
+				pruneTimeout := time.Duration(dbg.EnvInt("ERIGON_PRUNE_TIMEOUT_MS", 250)) * time.Millisecond
 				if initialCycle {
 					pruneTimeout = 10 * time.Hour
 

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -441,7 +441,7 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	if s.ForwardProgress > cfg.syncCfg.MaxReorgDepth && !cfg.syncCfg.AlwaysGenerateChangesets {
 		// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
 		// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
-		var pruneDiffsLimitOnChainTip = uint64(dbg.EnvInt("ERIGON_PRUNE_CHANGESETS_LIMIT", 1000))
+		var pruneDiffsLimitOnChainTip = dbg.EnvInt("ERIGON_PRUNE_CHANGESETS_LIMIT", 1000)
 		pruneTimeout := quickPruneTimeout
 		if s.CurrentSyncCycle.IsInitialCycle {
 			pruneDiffsLimitOnChainTip = math.MaxInt
@@ -453,7 +453,7 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 			kv.ChangeSets3,
 			s.ForwardProgress-cfg.syncCfg.MaxReorgDepth,
 			ctx,
-			int(pruneDiffsLimitOnChainTip),
+			pruneDiffsLimitOnChainTip,
 			pruneTimeout,
 			logger,
 			s.LogPrefix(),

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -436,12 +436,12 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	//  - stop prune when `tx.SpaceDirty()` is big
 	//  - and set ~500ms timeout
 	// because on slow disks - prune is slower. but for now - let's tune for nvme first, and add `tx.SpaceDirty()` check later https://github.com/erigontech/erigon/issues/11635
-	quickPruneTimeout := 500 * time.Millisecond
+	quickPruneTimeout := time.Duration(dbg.EnvInt("ERIGON_PRUNE_CHANGESETS_TIMEOUT_MS", 500)) * time.Millisecond
 
 	if s.ForwardProgress > cfg.syncCfg.MaxReorgDepth && !cfg.syncCfg.AlwaysGenerateChangesets {
 		// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
 		// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
-		var pruneDiffsLimitOnChainTip = 1_000
+		var pruneDiffsLimitOnChainTip = uint64(dbg.EnvInt("ERIGON_PRUNE_CHANGESETS_LIMIT", 1000))
 		pruneTimeout := quickPruneTimeout
 		if s.CurrentSyncCycle.IsInitialCycle {
 			pruneDiffsLimitOnChainTip = math.MaxInt
@@ -453,7 +453,7 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 			kv.ChangeSets3,
 			s.ForwardProgress-cfg.syncCfg.MaxReorgDepth,
 			ctx,
-			pruneDiffsLimitOnChainTip,
+			int(pruneDiffsLimitOnChainTip),
 			pruneTimeout,
 			logger,
 			s.LogPrefix(),

--- a/polygon/sync/header_time_validator.go
+++ b/polygon/sync/header_time_validator.go
@@ -114,6 +114,16 @@ func (htv *HeaderTimeValidator) needToWaitForNewSpan(header *types.Header, paren
 	headerNum := header.Number.Uint64()
 	// the current producer has published a block, but it came too late (i.e. the parent has been evicted from the ttl cache)
 	if author == producer && producer == parentAuthor && !htv.recentVerifiedHeaders.Has(header.ParentHash) {
+		// Guard against false positives caused by node-internal processing delays.
+		// The TTL cache eviction only means the node was slow — not that the chain
+		// itself had a large block-time gap.  Check the actual on-chain timestamp
+		// difference: if consecutive blocks from the same producer have a normal
+		// gap (≤ VeBlopBlockTimeout), no span rotation could have occurred and we
+		// should not stall for 12 seconds waiting for one.
+		onChainGap := time.Duration(header.Time-parent.Time) * time.Second
+		if onChainGap <= VeBlopBlockTimeout {
+			return false, 0, nil
+		}
 		htv.logger.Info("[span-rotation] need to wait for span rotation due to longer than expected block time from current producer", "blockNum", headerNum, "parentHeader", header.ParentHash, "author", author)
 		return true, VeBlopNewSpanTimeout, nil
 	}


### PR DESCRIPTION
This PR contains two improvements: 

1. Configurable Pruning Limits
Added 4 environment variables to control pruning behavior:
- `ERIGON_PRUNE_LIMIT` and `ERIGON_PRUNE_TIMEOUT_MS`: Control domain tables pruning (AccountsVals, StorageVals, CommitmentVals, CodeVals)
- `ERIGON_PRUNE_CHANGESETS_LIMIT` and `ERIGON_PRUNE_CHANGESETS_TIMEOUT_MS`: Control ChangeSets3 table pruning
Default limits (100-250ms for domains, 1000-500ms for ChangeSets) were insufficient for Polygon, causing CommitmentVals and ChangeSets3 tables to grow unbounded. This led to severe sync lags and excessive database size.
Increased limits to 10,000 entities with 2000ms timeouts, enabling effective pruning of accumulated data and maintaining MDBX database size within ~22GB.

2. Span Rotation Optimization
Added on-chain timestamp gap validation to prevent false positives in span rotation detection.