### PR TITLE
feat: collation improvement at the tip of the chain

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -241,14 +241,16 @@ func ExecV3(ctx context.Context,
 	chainReader := NewChainReaderImpl(cfg.chainConfig, applyTx, blockReader, logger)
 	agg := cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
 	if !inMemExec && !isMining {
+		// Always use 4 workers for file building to keep chaindata small.
+		// Chain-tip mode with only 1 worker can't keep up with high-throughput chains
+		// like Polygon, causing MDBX ReclaimableSpace to grow unbounded.
+		// 4 workers = all 4 domains (Accounts, Storage, Code, Commitment) in parallel.
+		agg.SetCollateAndBuildWorkers(min(4, estimate.StateV3Collate.Workers()))
+		agg.SetMergeWorkers(min(2, estimate.StateV3Collate.Workers()))
 		if initialCycle {
-			agg.SetCollateAndBuildWorkers(min(2, estimate.StateV3Collate.Workers()))
-			agg.SetMergeWorkers(min(1, estimate.StateV3Collate.Workers()))
 			agg.SetCompressWorkers(estimate.CompressSnapshot.Workers())
 		} else {
-			agg.SetCollateAndBuildWorkers(1)
-			agg.SetMergeWorkers(1)
-			agg.SetCompressWorkers(1)
+			agg.SetCompressWorkers(min(2, estimate.CompressSnapshot.Workers()))
 		}
 	}
 


### PR DESCRIPTION
A refactor in a prior commit restructured the worker-count assignment into initialCycle branches, accidentally leaving chain-tip mode (initialCycle=false) with only 1 collate/build worker instead of 4.                                                                             
On high-throughput chains like Polygon PoS, a single collation worker cannot keep pace with block execution. Domain steps fall behind, MDBX accumulates unflushed state faster than it can be collated, and `ReclaimableSpace` grows unbounded.                                                                                                                           

Fix: SetCollateAndBuildWorkers and SetMergeWorkers are now set unconditionally (outside the initialCycle branch), restoring 4 collate and 2 merge workers in both initial-sync and chain-tip modes. 
SetCompressWorkers retains the initialCycle distinction (full CPU during initial sync, capped at 2 at chain tip to avoid background I/O contention).