### PR TITLE
rpc: fix eth_subscribe logs with topic filters to preserve wildcard p…

### DIFF
--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -479,9 +479,11 @@ func (ff *Filters) SubscribeLogs(size int, criteria filters.FilterCriteria) (<-c
 					break
 				}
 			}
-			if len(allowedTopicsRow) > 0 {
-				allowedTopics = append(allowedTopics, allowedTopicsRow)
-			}
+			// BUG FIX: Removed guard that was dropping empty topic rows (wildcards)
+			// This was causing eth_subscribe with topic filters to return no events
+			// because wildcard positions (empty arrays) were being skipped, causing
+			// positional misalignment in topic matching
+			allowedTopics = append(allowedTopics, allowedTopicsRow)
 		}
 		f.topicsOriginal = allowedTopics
 	}


### PR DESCRIPTION
…ositions

The SubscribeLogs function was incorrectly dropping empty topic rows (wildcards) by checking if len(allowedTopicsRow) > 0 before appending. This caused positional misalignment in topic matching, leading to eth_subscribe with indexed topics returning no events even when matching logs existed.

Example: A filter like [signature, null, address, null] would become [signature, address] because the null (wildcard) rows were dropped, making the filter match the wrong topic positions.

This fix removes the guard and always appends the topic row, preserving wildcard positions and ensuring correct topic filtering behavior.

Fixes: https://github.com/erigontech/erigon/issues/4030