### PR TITLE
execution/type: Fix invalid RLP encoding of StateSync transactions

### DIFF
--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -537,6 +537,43 @@ func TestWithdrawalsEncoding(t *testing.T) {
 	assert.Equal(t, block2.Hash(), decoded2.Hash())
 }
 
+// TestBlockWithStateSyncTxRoundtrip ensures that we can RLP-roundtrip a block with a state-sync tx.
+// `func (tx *StateSyncTx) EncodingSize() int` had an issue where it was double-counting bytes.
+func TestBlockWithStateSyncTxRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	stateSyncTx := &StateSyncTx{
+		StateSyncData: []*StateSyncData{
+			{
+				ID:       1,
+				Contract: common.Address{0x42},
+				Data:     nil,
+				TxHash:   common.Hash{0x99},
+			},
+		},
+	}
+
+	header := &Header{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+		GasLimit:   1,
+		Time:       1,
+		Extra:      []byte{},
+	}
+
+	block := NewBlockFromStorage(common.Hash{}, header, []Transaction{stateSyncTx}, nil, nil)
+
+	encoded, err := rlp.EncodeToBytes(block)
+	require.NoError(t, err)
+
+	var decoded Block
+	require.NoError(t, rlp.DecodeBytes(encoded, &decoded),
+		"encoded block must round-trip; encoded %d bytes", len(encoded))
+
+	require.Len(t, decoded.Transactions(), 1)
+	require.Equal(t, byte(StateSyncTxType), decoded.Transactions()[0].Type())
+}
+
 func TestBlockRawBodyPreShanghai(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/execution/types/state_sync_tx.go
+++ b/execution/types/state_sync_tx.go
@@ -132,10 +132,10 @@ func (tx *StateSyncTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint25
 }
 
 func (tx *StateSyncTx) EncodingSize() int {
+	// Return the inner size (type byte + RLP body)
 	var b bytes.Buffer
 	_ = tx.encode(&b)
-	data := make([]byte, 1+b.Len())
-	return rlp.StringLen(data)
+	return 1 + b.Len()
 }
 
 // EncodeRLP implements rlp.Encoder for database storage.


### PR DESCRIPTION
`EncodingSize()` must return the inner size, and not the size of the already RLP-encoded tx.

This triggered issues on Blocks sent via the P2P layer which were sending RLP-encoded blocks declared as having 2 or 3 bytes more than the actual data, leading to failures to decode.