### PR TITLE
fix(exec3): prevent execution loop on zero-gas block regions during initial sync

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -812,7 +812,7 @@ Loop:
 		// if we're in the initialCycle before we consider the blockLimit we need to make sure we keep executing
 		// until we reach a transaction whose comittement which is writable to the db, otherwise the update will get lost
 		if !initialCycle || lastExecutedStep > 0 && lastExecutedStep > lastFrozenStep && !dbg.DiscardCommitment() {
-			if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit {
+			if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit && totalGasUsed > 0 {
 				errExhausted = &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block limit reached"}
 				break
 			}


### PR DESCRIPTION
Fixes: https://github.com/0xPolygon/erigon/issues/150

## Problem

When syncing Polygon `bor-mainnet` from genesis (`--no-downloader`), the execution stage enters an infinite loop at ~block 856,625. The node repeatedly processes the same 5,000 block batch without advancing because:

1. Early Polygon blocks have zero gas/zero transactions
2. `LoopBlockLimit` (5000) fires and breaks the execution loop
3. Commitment cannot be saved (txNum is between step boundaries)
4. Next `ExecV3` call reads the same old commitment position → infinite loop

## Fix

Add `totalGasUsed > 0` to the block limit condition:

```diff
- if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit {
+ if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit && totalGasUsed > 0 {
```

This lets execution continue through zero-gas block regions (~80K blk/s, essentially free) until blocks with actual state changes are reached where commitment CAN be saved.

## Testing

- **Before**: Node stuck at block 856,625 (infinite loop)
- **After**: Node advanced past 1,100,000+ blocks and counting
- `totalGasUsed` is already tracked in the execution loop (line 727), no new variables needed
- Zero-gas blocks produce no state changes, so processing more is safe and fast