### PR TITLE
core, execution, p2p, polygon: chicago hf for v3.6.0 release

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -60,6 +60,8 @@ type PrecompiledContract interface {
 
 func Precompiles(chainRules *chain.Rules) map[common.Address]PrecompiledContract {
 	switch {
+	case chainRules.IsChicago:
+		return PrecompiledContractsChicago
 	case chainRules.IsLisovoPro:
 		return PrecompiledContractsLisovoPro
 	case chainRules.IsLisovo:
@@ -312,7 +314,30 @@ var PrecompiledContractsLisovoPro = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{eip7951: true},
 }
 
+// PrecompiledContractsChicago contains the set of pre-compiled Ethereum
+// contracts used in the Chicago release (bor HF).
+var PrecompiledContractsChicago = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{0x01}):       &ecrecover{},
+	common.BytesToAddress([]byte{0x02}):       &sha256hash{},
+	common.BytesToAddress([]byte{0x03}):       &ripemd160hash{},
+	common.BytesToAddress([]byte{0x04}):       &dataCopy{},
+	common.BytesToAddress([]byte{0x05}):       &bigModExp{madhugiri: true},
+	common.BytesToAddress([]byte{0x06}):       &bn254AddIstanbul{pip88: true},
+	common.BytesToAddress([]byte{0x07}):       &bn254ScalarMulIstanbul{pip88: true},
+	common.BytesToAddress([]byte{0x08}):       &bn254PairingIstanbul{pip88: true},
+	common.BytesToAddress([]byte{0x09}):       &blake2F{pip88: true},
+	common.BytesToAddress([]byte{0x0b}):       &bls12381G1Add{pip88: true},
+	common.BytesToAddress([]byte{0x0c}):       &bls12381G1MultiExp{pip88: true},
+	common.BytesToAddress([]byte{0x0d}):       &bls12381G2Add{pip88: true},
+	common.BytesToAddress([]byte{0x0e}):       &bls12381G2MultiExp{pip88: true},
+	common.BytesToAddress([]byte{0x0f}):       &bls12381Pairing{pip88: true},
+	common.BytesToAddress([]byte{0x10}):       &bls12381MapFpToG1{pip88: true},
+	common.BytesToAddress([]byte{0x11}):       &bls12381MapFp2ToG2{pip88: true},
+	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{eip7951: true},
+}
+
 var (
+	PrecompiledAddressesChicago      []common.Address
 	PrecompiledAddressesLisovoPro    []common.Address
 	PrecompiledAddressesLisovo       []common.Address
 	PrecompiledAddressesMadhugiriPro []common.Address
@@ -368,11 +393,16 @@ func init() {
 	for k := range PrecompiledContractsLisovoPro {
 		PrecompiledAddressesLisovoPro = append(PrecompiledAddressesLisovoPro, k)
 	}
+	for k := range PrecompiledContractsChicago {
+		PrecompiledAddressesChicago = append(PrecompiledAddressesChicago, k)
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules *chain.Rules) []common.Address {
 	switch {
+	case rules.IsChicago:
+		return PrecompiledAddressesChicago
 	case rules.IsLisovoPro:
 		return PrecompiledAddressesLisovoPro
 	case rules.IsLisovo:
@@ -760,10 +790,15 @@ func runBn254Add(input []byte) ([]byte, error) {
 
 // bn254Add implements a native elliptic curve point addition conforming to
 // Istanbul consensus rules.
-type bn254AddIstanbul struct{}
+type bn254AddIstanbul struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn254AddIstanbul) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bn254AddGasIstanbulPIP88
+	}
 	return params.Bn254AddGasIstanbul
 }
 
@@ -805,10 +840,15 @@ func runBn254ScalarMul(input []byte) ([]byte, error) {
 
 // bn254ScalarMulIstanbul implements a native elliptic curve scalar
 // multiplication conforming to Istanbul consensus rules.
-type bn254ScalarMulIstanbul struct{}
+type bn254ScalarMulIstanbul struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn254ScalarMulIstanbul) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bn254ScalarMulGasIstanbulPIP88
+	}
 	return params.Bn254ScalarMulGasIstanbul
 }
 
@@ -890,10 +930,15 @@ func runBn254Pairing(input []byte) ([]byte, error) {
 
 // bn254PairingIstanbul implements a pairing pre-compile for the bn254 curve
 // conforming to Istanbul consensus rules.
-type bn254PairingIstanbul struct{}
+type bn254PairingIstanbul struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn254PairingIstanbul) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bn254PairingBaseGasIstanbulPIP88 + uint64(len(input)/192)*params.Bn254PairingPerPointGasIstanbulPIP88
+	}
 	return params.Bn254PairingBaseGasIstanbul + uint64(len(input)/192)*params.Bn254PairingPerPointGasIstanbul
 }
 
@@ -922,7 +967,9 @@ func (c *bn254PairingByzantium) Name() string {
 	return "BN254_PAIRING" // note bn254 is the correct name and is required by eth_config
 }
 
-type blake2F struct{}
+type blake2F struct {
+	pip88 bool
+}
 
 func (c *blake2F) RequiredGas(input []byte) uint64 {
 	// If the input is malformed, we can't calculate the gas, return 0 and let the
@@ -930,7 +977,14 @@ func (c *blake2F) RequiredGas(input []byte) uint64 {
 	if len(input) != blake2FInputLength {
 		return 0
 	}
-	return uint64(binary.BigEndian.Uint32(input[0:4]))
+	// Per EIP-152, each blake2F operation costs GFROUND * rounds gas, where GFROUND = 1.
+	// PIP-88 raises GFROUND to 22 (params.GFROUNDPIP88).
+	// rounds is bounded by uint32 so multiplying by params.GFROUNDPIP88 cannot overflow uint64.
+	rounds := uint64(binary.BigEndian.Uint32(input[0:4]))
+	if c.pip88 {
+		return rounds * params.GFROUNDPIP88
+	}
+	return rounds
 }
 
 const (
@@ -995,10 +1049,15 @@ var (
 )
 
 // bls12381G1Add implements EIP-2537 G1Add precompile.
-type bls12381G1Add struct{}
+type bls12381G1Add struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G1Add) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bls12381G1AddGasPIP88
+	}
 	return params.Bls12381G1AddGas
 }
 
@@ -1033,7 +1092,9 @@ func (c *bls12381G1Add) Name() string {
 }
 
 // bls12381G1MultiExp implements EIP-2537 G1MultiExp precompile.
-type bls12381G1MultiExp struct{}
+type bls12381G1MultiExp struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
@@ -1050,8 +1111,12 @@ func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
 	} else {
 		discount = params.Bls12381MSMDiscountTableG1[dLen-1]
 	}
+	mulGas := params.Bls12381G1MulGas
+	if c.pip88 {
+		mulGas = params.Bls12381G1MulGasPIP88
+	}
 	// Calculate gas and return the result
-	return (uint64(k) * params.Bls12381G1MulGas * discount) / 1000
+	return (uint64(k) * mulGas * discount) / 1000
 }
 
 func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
@@ -1096,10 +1161,15 @@ func (c *bls12381G1MultiExp) Name() string {
 }
 
 // bls12381G2Add implements EIP-2537 G2Add precompile.
-type bls12381G2Add struct{}
+type bls12381G2Add struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G2Add) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bls12381G2AddGasPIP88
+	}
 	return params.Bls12381G2AddGas
 }
 
@@ -1135,7 +1205,9 @@ func (c *bls12381G2Add) Name() string {
 }
 
 // bls12381G2MultiExp implements EIP-2537 G2MultiExp precompile.
-type bls12381G2MultiExp struct{}
+type bls12381G2MultiExp struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
@@ -1152,8 +1224,12 @@ func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	} else {
 		discount = params.Bls12381MSMDiscountTableG2[dLen-1]
 	}
+	mulGas := params.Bls12381G2MulGas
+	if c.pip88 {
+		mulGas = params.Bls12381G2MulGasPIP88
+	}
 	// Calculate gas and return the result
-	return (uint64(k) * params.Bls12381G2MulGas * discount) / 1000
+	return (uint64(k) * mulGas * discount) / 1000
 }
 
 func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
@@ -1198,10 +1274,15 @@ func (c *bls12381G2MultiExp) Name() string {
 }
 
 // bls12381Pairing implements EIP-2537 Pairing precompile.
-type bls12381Pairing struct{}
+type bls12381Pairing struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381Pairing) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bls12381PairingBaseGasPIP88 + uint64(len(input)/384)*params.Bls12381PairingPerPairGasPIP88
+	}
 	return params.Bls12381PairingBaseGas + uint64(len(input)/384)*params.Bls12381PairingPerPairGas
 }
 
@@ -1354,10 +1435,15 @@ func encodePointG2(p *bls12381.G2Affine) []byte {
 }
 
 // bls12381MapFpToG1 implements EIP-2537 MapG1 precompile.
-type bls12381MapFpToG1 struct{}
+type bls12381MapFpToG1 struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381MapFpToG1) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bls12381MapFpToG1GasPIP88
+	}
 	return params.Bls12381MapFpToG1Gas
 }
 
@@ -1387,10 +1473,15 @@ func (c *bls12381MapFpToG1) Name() string {
 }
 
 // bls12381MapFp2ToG2 implements EIP-2537 MapG2 precompile.
-type bls12381MapFp2ToG2 struct{}
+type bls12381MapFp2ToG2 struct {
+	pip88 bool
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381MapFp2ToG2) RequiredGas(input []byte) uint64 {
+	if c.pip88 {
+		return params.Bls12381MapFp2ToG2GasPIP88
+	}
 	return params.Bls12381MapFp2ToG2Gas
 }
 

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -23,18 +23,23 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/math"
+	"github.com/erigontech/erigon/core/state"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/params"
+	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
 
 // precompiledTest defines the input/output pairs for precompiled contract tests.
@@ -554,6 +559,7 @@ func TestPointEvaluationPrecompileRemoval(t *testing.T) {
 		{name: "MadhugiriPro", rules: chain.Rules{IsMadhugiriPro: true}, shouldHaveKzg: true},
 		{name: "Lisovo", rules: chain.Rules{IsLisovo: true}, shouldHaveKzg: true},
 		{name: "LisovoPro", rules: chain.Rules{IsLisovoPro: true}, shouldHaveKzg: false},
+		{name: "Chicago", rules: chain.Rules{IsChicago: true}, shouldHaveKzg: false},
 	}
 	for _, tc := range cases {
 		precompiles := Precompiles(&tc.rules)
@@ -567,5 +573,294 @@ func TestPointEvaluationPrecompileRemoval(t *testing.T) {
 		if exists && pc.Name() != kzgPointEvaluationPrecompile.Name() {
 			t.Errorf("invalid precompile loaded instead of kzgPointEvaluation (0x0a). expected name: %s, got name: %s, test case: %s", kzgPointEvaluationPrecompile.Name(), pc.Name(), tc.name)
 		}
+	}
+}
+
+// pip88StorageReader is a minimal state.StateReader that returns a configured
+// committed-storage value for one (address, slot) pair. It lets the SStore
+// test populate "original" (committed) state without going through a real
+// commit, mirroring the Finalise(false) trick used in the bor test.
+type pip88StorageReader struct {
+	state.NoopReader
+	addr common.Address
+	slot common.Hash
+	val  uint256.Int
+}
+
+func (r *pip88StorageReader) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
+	if address == r.addr && key == r.slot {
+		return r.val, true, nil
+	}
+	return uint256.Int{}, false, nil
+}
+
+// TestPIP88PrecompileGasCosts verifies pre- and post-PIP-88 gas for every
+// precompile repriced by the Chicago fork.
+func TestPIP88PrecompileGasCosts(t *testing.T) {
+	t.Parallel()
+
+	// blake2F input: 213 bytes, rounds=12 in big-endian uint32 at [0:4].
+	blake2FInput := make([]byte, 213)
+	blake2FInput[3] = 12
+
+	cases := []struct {
+		addr    byte
+		input   []byte
+		preGas  uint64
+		postGas uint64
+		name    string
+	}{
+		{0x06, nil, params.Bn254AddGasIstanbul, params.Bn254AddGasIstanbulPIP88, "bn254Add (3.6x)"},
+		{0x07, nil, params.Bn254ScalarMulGasIstanbul, params.Bn254ScalarMulGasIstanbulPIP88, "bn254ScalarMul (2.1x)"},
+		{0x0b, nil, params.Bls12381G1AddGas, params.Bls12381G1AddGasPIP88, "bls12381G1Add (2.8x)"},
+		{0x0d, nil, params.Bls12381G2AddGas, params.Bls12381G2AddGasPIP88, "bls12381G2Add (2.7x)"},
+		{0x10, nil, params.Bls12381MapFpToG1Gas, params.Bls12381MapFpToG1GasPIP88, "bls12381MapFpToG1 (2.8x)"},
+		{0x11, nil, params.Bls12381MapFp2ToG2Gas, params.Bls12381MapFp2ToG2GasPIP88, "bls12381MapFp2ToG2 (2.8x)"},
+		{
+			addr:    0x08,
+			input:   make([]byte, 192),
+			preGas:  params.Bn254PairingBaseGasIstanbul + params.Bn254PairingPerPointGasIstanbul,
+			postGas: params.Bn254PairingBaseGasIstanbulPIP88 + params.Bn254PairingPerPointGasIstanbulPIP88,
+			name:    "bn254Pairing k=1 (1.5x)",
+		},
+		{
+			addr:    0x0f,
+			input:   make([]byte, 384),
+			preGas:  params.Bls12381PairingBaseGas + params.Bls12381PairingPerPairGas,
+			postGas: params.Bls12381PairingBaseGasPIP88 + params.Bls12381PairingPerPairGasPIP88,
+			name:    "bls12381Pairing k=1 (2.9x)",
+		},
+		// MSM at k=1: discount table[0]=1000, so gas = mulGas.
+		{0x0c, make([]byte, 160), params.Bls12381G1MulGas, params.Bls12381G1MulGasPIP88, "bls12381G1MultiExp k=1 (6.1x)"},
+		{0x0e, make([]byte, 288), params.Bls12381G2MulGas, params.Bls12381G2MulGasPIP88, "bls12381G2MultiExp k=1 (6.4x)"},
+		{0x09, blake2FInput, 12, 12 * params.GFROUNDPIP88, "blake2F rounds=12 (22x)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := common.BytesToAddress([]byte{tc.addr})
+
+			pre, ok := PrecompiledContractsLisovoPro[addr]
+			if !ok {
+				t.Fatalf("0x%02x missing from PrecompiledContractsLisovoPro", tc.addr)
+			}
+			post, ok := PrecompiledContractsChicago[addr]
+			if !ok {
+				t.Fatalf("0x%02x missing from PrecompiledContractsChicago", tc.addr)
+			}
+
+			if got := pre.RequiredGas(tc.input); got != tc.preGas {
+				t.Errorf("pre-PIP-88 gas: got %d, want %d", got, tc.preGas)
+			}
+			if got := post.RequiredGas(tc.input); got != tc.postGas {
+				t.Errorf("post-PIP-88 gas: got %d, want %d", got, tc.postGas)
+			}
+		})
+	}
+}
+
+// TestPIP88SStoreGas walks every branch of makeGasSStoreFuncPIP88 and verifies
+// the gas charged and refund-pool delta match closed-form values.
+func TestPIP88SStoreGas(t *testing.T) {
+	t.Parallel()
+
+	addr := common.Address{0xaa}
+	slot := common.BigToHash(big.NewInt(1))
+	val42 := *uint256.NewInt(0x42)
+	val99 := *uint256.NewInt(0x99)
+	zero := uint256.Int{}
+
+	cases := []struct {
+		name            string
+		original        uint256.Int // committed value before this tx
+		current         uint256.Int // dirty value (only applied if != original)
+		value           uint256.Int // value being written by SSTORE
+		warm            bool
+		wantGas         uint64
+		wantRefundDelta int64
+	}{
+		{
+			name:     "cold reset existing slot (EIP-2929 invariant: total = 5000)",
+			original: val42, current: val42, value: val99, warm: false,
+			wantGas: params.SstoreResetGasEIP2200, wantRefundDelta: 0,
+		},
+		{
+			name:     "warm reset existing slot",
+			original: val42, current: val42, value: val99, warm: true,
+			wantGas: params.SstoreResetGasEIP2200 - params.ColdSstoreCostPIP88, wantRefundDelta: 0,
+		},
+		{
+			name:     "cold create slot",
+			original: zero, current: zero, value: val99, warm: false,
+			wantGas: params.ColdSstoreCostPIP88 + params.SstoreSetGasEIP2200, wantRefundDelta: 0,
+		},
+		{
+			name:     "cold delete clean slot (clearingRefund = SstoreClearsScheduleRefundPIP88)",
+			original: val42, current: val42, value: zero, warm: false,
+			wantGas:         params.SstoreResetGasEIP2200,
+			wantRefundDelta: int64(params.SstoreClearsScheduleRefundPIP88),
+		},
+		{
+			name:     "cold noop (current == value)",
+			original: val42, current: val42, value: val42, warm: false,
+			wantGas: params.ColdSstoreCostPIP88 + params.WarmStorageReadCostEIP2929, wantRefundDelta: 0,
+		},
+		{
+			name:     "reset to original existing slot (refund = (RESET - cold) - warm)",
+			original: val42, current: val99, value: val42, warm: true,
+			wantGas:         params.WarmStorageReadCostEIP2929,
+			wantRefundDelta: int64((params.SstoreResetGasEIP2200 - params.ColdSstoreCostPIP88) - params.WarmStorageReadCostEIP2929),
+		},
+		{
+			name:     "reset to clean zero (refund = SstoreSet - warm, unchanged from EIP-3529)",
+			original: zero, current: val99, value: zero, warm: true,
+			wantGas:         params.WarmStorageReadCostEIP2929,
+			wantRefundDelta: int64(params.SstoreSetGasEIP2200 - params.WarmStorageReadCostEIP2929),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// pip88StorageReader supplies tc.original as the committed value for slot.
+			reader := &pip88StorageReader{addr: addr, slot: slot, val: tc.original}
+			statedb := state.New(reader)
+			require.NoError(t, statedb.CreateAccount(addr, false))
+
+			// Apply dirty current value when it differs from committed original.
+			if !tc.current.Eq(&tc.original) {
+				require.NoError(t, statedb.SetState(addr, slot, tc.current))
+			}
+			if tc.warm {
+				statedb.AddSlotToAccessList(addr, slot)
+			}
+
+			evm := NewEVM(
+				evmtypes.BlockContext{BlockNumber: 1, Time: 1, PrevRanDao: &common.Hash{}},
+				evmtypes.TxContext{},
+				statedb, chain.TestChainBorConfig, Config{},
+			)
+			contract := NewContract(AccountRef(common.Address{}), addr, uint256.NewInt(0), 1_000_000, false, NewJumpDestCache(16))
+
+			stack := New()
+			stack.push(new(uint256.Int).Set(&tc.value))         // Back(1) = value
+			stack.push(new(uint256.Int).SetBytes(slot.Bytes())) // peek = slot
+
+			refundBefore := statedb.GetRefund()
+			gas, err := gasSStorePIP88(evm, contract, stack, NewMemory(), 0)
+			if err != nil {
+				t.Fatalf("gasSStorePIP88 returned error: %v", err)
+			}
+			refundDelta := int64(statedb.GetRefund()) - int64(refundBefore)
+
+			if gas != tc.wantGas {
+				t.Errorf("gas: got %d, want %d", gas, tc.wantGas)
+			}
+			if refundDelta != tc.wantRefundDelta {
+				t.Errorf("refund delta: got %d, want %d", refundDelta, tc.wantRefundDelta)
+			}
+		})
+	}
+}
+
+// TestPIP88ForkBoundary verifies that the Chicago fork dispatch flips at the
+// configured block: precompile set and SLOAD instruction-set gas function both
+// switch from EIP-3529/LisovoPro to PIP-88 at block N (with N-1 still old).
+func TestPIP88ForkBoundary(t *testing.T) {
+	t.Parallel()
+
+	const chicagoBlock = 100
+
+	// Construct a minimal bor chain config with Chicago pushed to a specific
+	// block so we have a real boundary to test against. All earlier height
+	// forks default to active at block 0 (matching TestChainBorConfig).
+	cfg := &chain.Config{
+		ChainID:               big.NewInt(1337),
+		Consensus:             chain.BorConsensus,
+		HomesteadBlock:        big.NewInt(0),
+		TangerineWhistleBlock: big.NewInt(0),
+		SpuriousDragonBlock:   big.NewInt(0),
+		ByzantiumBlock:        big.NewInt(0),
+		ConstantinopleBlock:   big.NewInt(0),
+		PetersburgBlock:       big.NewInt(0),
+		IstanbulBlock:         big.NewInt(0),
+		MuirGlacierBlock:      big.NewInt(0),
+		BerlinBlock:           big.NewInt(0),
+		LondonBlock:           big.NewInt(0),
+		Bor: &borcfg.BorConfig{
+			AgraBlock:         big.NewInt(0),
+			NapoliBlock:       big.NewInt(0),
+			AhmedabadBlock:    big.NewInt(0),
+			BhilaiBlock:       big.NewInt(0),
+			RioBlock:          big.NewInt(0),
+			MadhugiriBlock:    big.NewInt(0),
+			MadhugiriProBlock: big.NewInt(0),
+			LisovoBlock:       big.NewInt(0),
+			LisovoProBlock:    big.NewInt(0),
+			GiuglianoBlock:    big.NewInt(0),
+			ChicagoBlock:      big.NewInt(chicagoBlock),
+		},
+	}
+
+	addr := common.Address{0xaa}
+	slot := common.BigToHash(big.NewInt(1))
+
+	cases := []struct {
+		name             string
+		block            uint64
+		wantIsChicago    bool
+		wantBn254AddGas  uint64 // probe for ActivePrecompiledContracts dispatch
+		wantColdSloadGas uint64 // probe for instruction-set dispatch
+	}{
+		{
+			name:             "block N-1 (pre-Chicago)",
+			block:            chicagoBlock - 1,
+			wantIsChicago:    false,
+			wantBn254AddGas:  params.Bn254AddGasIstanbul,
+			wantColdSloadGas: params.ColdSloadCostEIP2929,
+		},
+		{
+			name:             "block N (Chicago active)",
+			block:            chicagoBlock,
+			wantIsChicago:    true,
+			wantBn254AddGas:  params.Bn254AddGasIstanbulPIP88,
+			wantColdSloadGas: params.ColdSloadCostPIP88,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bc := evmtypes.BlockContext{BlockNumber: tc.block, Time: 1}
+			rules := bc.Rules(cfg)
+			if rules.IsChicago != tc.wantIsChicago {
+				t.Fatalf("rules.IsChicago: got %v, want %v", rules.IsChicago, tc.wantIsChicago)
+			}
+
+			// Precompile dispatch probe.
+			bn254Add := Precompiles(rules)[common.BytesToAddress([]byte{0x06})]
+			if got := bn254Add.RequiredGas(nil); got != tc.wantBn254AddGas {
+				t.Errorf("bn254Add gas via Precompiles: got %d, want %d", got, tc.wantBn254AddGas)
+			}
+
+			// Instruction-set dispatch probe via SLOAD's dynamicGas on a cold slot.
+			statedb := state.New(state.NewNoopReader())
+			require.NoError(t, statedb.CreateAccount(addr, false))
+			evm := NewEVM(
+				evmtypes.BlockContext{BlockNumber: tc.block, Time: 1, PrevRanDao: &common.Hash{}},
+				evmtypes.TxContext{},
+				statedb, cfg, Config{},
+			)
+			contract := NewContract(AccountRef(common.Address{}), addr, uint256.NewInt(0), 1_000_000, false, NewJumpDestCache(16))
+			stack := New()
+			stack.push(new(uint256.Int).SetBytes(slot.Bytes()))
+
+			jt := evm.Interpreter().(*EVMInterpreter).jt
+			gas, err := jt[SLOAD].dynamicGas(evm, contract, stack, NewMemory(), 0)
+			if err != nil {
+				t.Fatalf("SLOAD dynamicGas: %v", err)
+			}
+			if gas != tc.wantColdSloadGas {
+				t.Errorf("cold SLOAD gas: got %d, want %d", gas, tc.wantColdSloadGas)
+			}
+		})
 	}
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -170,6 +170,15 @@ func enable3529(jt *JumpTable) {
 	jt[SELFDESTRUCT].dynamicGas = gasSelfdestructEIP3529
 }
 
+// enablePIP88 applies PIP-88:
+// - Increases the cost of cold SLOAD to params.ColdSloadCostPIP88 (2.6x)
+// - Increases the cost of cold SSTORE to params.ColdSstoreCostPIP88 (1.4x)
+// - Recomputes the slot-clear refund to params.SstoreClearsScheduleRefundPIP88
+func enablePIP88(jt *JumpTable) {
+	jt[SLOAD].dynamicGas = gasSLoadPIP88
+	jt[SSTORE].dynamicGas = gasSStorePIP88
+}
+
 // enable3198 applies EIP-3198 (BASEFEE Opcode)
 // - Adds an opcode that returns the current block's base fee.
 func enable3198(jt *JumpTable) {

--- a/core/vm/evmtypes/rules.go
+++ b/core/vm/evmtypes/rules.go
@@ -53,5 +53,6 @@ func (bc *BlockContext) Rules(c *chain.Config) *chain.Rules {
 		IsLisovo:           c.IsLisovo(bc.BlockNumber),
 		IsLisovoPro:        c.IsLisovoPro(bc.BlockNumber),
 		IsGiugliano:        c.IsGiugliano(bc.BlockNumber),
+		IsChicago:          c.IsChicago(bc.BlockNumber),
 	}
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -181,6 +181,8 @@ type EVMInterpreter struct {
 func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	var jt *JumpTable
 	switch {
+	case evm.chainRules.IsChicago:
+		jt = &chicagoInstructionSet
 	case evm.chainRules.IsLisovoPro:
 		jt = &lisovoProInstructionSet
 	case evm.chainRules.IsLisovo:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -72,6 +72,7 @@ var (
 	osakaInstructionSet            = newOsakaInstructionSet()
 	lisovoInstructionSet           = newLisovoInstructionSet()
 	lisovoProInstructionSet        = newLisovoProInstructionSet()
+	chicagoInstructionSet          = newChicagoInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -303,6 +304,13 @@ func newLisovoInstructionSet() JumpTable {
 func newLisovoProInstructionSet() JumpTable {
 	instructionSet := newBhilaiInstructionSet()
 	enable7939(&instructionSet) // EIP-7939 (CLZ opcode)
+	validateAndFillMaxStack(&instructionSet)
+	return instructionSet
+}
+
+func newChicagoInstructionSet() JumpTable {
+	instructionSet := newLisovoProInstructionSet()
+	enablePIP88(&instructionSet) // PIP-88: cold-storage repricing
 	validateAndFillMaxStack(&instructionSet)
 	return instructionSet
 }

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -30,6 +30,78 @@ import (
 	"github.com/erigontech/erigon/execution/chain/params"
 )
 
+func makeGasSStoreFuncPIP88(clearingRefund uint64) gasFunc {
+	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+		// If we fail the minimum gas availability invariant, fail (0)
+		if contract.Gas <= params.SstoreSentryGasEIP2200 {
+			return 0, errors.New("not enough gas for reentrancy sentry")
+		}
+		// Gas sentry honoured, do the actual gas calculation based on the stored value
+		var (
+			y, x    = stack.Back(1), stack.peek()
+			slot    = common.Hash(x.Bytes32())
+			current uint256.Int
+			cost    = uint64(0)
+		)
+
+		evm.IntraBlockState().GetState(contract.Address(), slot, &current)
+		// PIP-88: charge ColdSstoreCostPIP88. Must match the constant
+		// subtracted in the SSTORE_RESET formula below so the EIP-2929
+		// invariant `cold + (RESET - cold) == RESET` (5000) still holds.
+		if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(contract.Address(), slot); slotMod {
+			cost = params.ColdSstoreCostPIP88
+		}
+		var value uint256.Int
+		value.Set(y)
+
+		if current.Eq(&value) { // noop (1)
+			// EIP 2200 original clause:
+			//		return params.SloadGasEIP2200, nil
+			return cost + params.WarmStorageReadCostEIP2929, nil // SLOAD_GAS
+		}
+		var original uint256.Int
+		slotCommited := common.Hash(x.Bytes32())
+		evm.IntraBlockState().GetCommittedState(contract.Address(), slotCommited, &original)
+		if original.Eq(&current) {
+			if original.IsZero() { // create slot (2.1.1)
+				return cost + params.SstoreSetGasEIP2200, nil
+			}
+			if value.IsZero() { // delete slot (2.1.2b)
+				evm.IntraBlockState().AddRefund(clearingRefund)
+			}
+			// EIP-2200 original clause:
+			//		return params.SstoreResetGasEIP2200, nil // write existing slot (2.1.2)
+			// PIP-88: use ColdSstoreCostPIP88.
+			return cost + (params.SstoreResetGasEIP2200 - params.ColdSstoreCostPIP88), nil // write existing slot (2.1.2)
+		}
+		if !original.IsZero() {
+			if current.IsZero() { // recreate slot (2.2.1.1)
+				evm.IntraBlockState().SubRefund(clearingRefund)
+			} else if value.IsZero() { // delete slot (2.2.1.2)
+				evm.IntraBlockState().AddRefund(clearingRefund)
+			}
+		}
+		if original.Eq(&value) {
+			if original.IsZero() { // reset to original inexistent slot (2.2.2.1)
+				// EIP 2200 Original clause:
+				//evm.StateDB.AddRefund(params.SstoreSetGasEIP2200 - params.SloadGasEIP2200)
+				evm.IntraBlockState().AddRefund(params.SstoreSetGasEIP2200 - params.WarmStorageReadCostEIP2929)
+			} else { // reset to original existing slot (2.2.2.2)
+				// EIP 2200 Original clause:
+				//	evm.StateDB.AddRefund(params.SstoreResetGasEIP2200 - params.SloadGasEIP2200)
+				// - SSTORE_RESET_GAS redefined as (5000 - COLD_SLOAD_COST)
+				// - SLOAD_GAS redefined as WARM_STORAGE_READ_COST
+				// Final: (5000 - COLD_SLOAD_COST) - WARM_STORAGE_READ_COST
+				// PIP-88: use ColdSstoreCostPIP88.
+				evm.IntraBlockState().AddRefund((params.SstoreResetGasEIP2200 - params.ColdSstoreCostPIP88) - params.WarmStorageReadCostEIP2929)
+			}
+		}
+		// EIP-2200 original clause:
+		//return params.SloadGasEIP2200, nil // dirty update (2.2)
+		return cost + params.WarmStorageReadCostEIP2929, nil // dirty update (2.2)
+	}
+}
+
 func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 		// If we fail the minimum gas availability invariant, fail (0)
@@ -109,6 +181,22 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	// If he does afford it, we can skip checking the same thing later on, during execution
 	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(contract.Address(), loc.Bytes32()); slotMod {
 		return params.ColdSloadCostEIP2929, nil
+	}
+	return params.WarmStorageReadCostEIP2929, nil
+}
+
+// gasSLoadPIP88 calculates dynamic gas for SLOAD according to PIP-88
+// For SLOAD, if the (address, storage_key) pair (where address is the address of the contract
+// whose storage is being read) is not yet in accessed_storage_keys,
+// charge 2100 gas and add the pair to accessed_storage_keys.
+// If the pair is already in accessed_storage_keys, charge 100 gas.
+// Warm storage read cost remains the same as EIP-2929.
+func gasSLoadPIP88(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	loc := stack.peek()
+	// If the caller cannot afford the cost, this change will be rolled back
+	// If he does afford it, we can skip checking the same thing later on, during execution
+	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(contract.Address(), loc.Bytes32()); slotMod {
+		return params.ColdSloadCostPIP88, nil
 	}
 	return params.WarmStorageReadCostEIP2929, nil
 }
@@ -215,6 +303,9 @@ var (
 	// gasSStoreEIP2539 implements gas cost for SSTORE according to EPI-2539
 	// Replace `SSTORE_CLEARS_SCHEDULE` with `SSTORE_RESET_GAS + ACCESS_LIST_STORAGE_KEY_COST` (4,800)
 	gasSStoreEIP3529 = makeGasSStoreFunc(params.SstoreClearsScheduleRefundEIP3529)
+
+	// gasSStorePIP88 implements gas cost for SSTORE according to PIP-88
+	gasSStorePIP88 = makeGasSStoreFuncPIP88(params.SstoreClearsScheduleRefundPIP88)
 )
 
 // makeSelfdestructGasFn can create the selfdestruct dynamic gas function for EIP-2929 and EIP-2539

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -32,7 +32,7 @@ const (
 	Major                    = 3      // Major version component of the current release
 	Minor                    = 6      // Minor version component of the current release
 	Micro                    = 0      // Micro version component of the current release
-	Modifier                 = "beta" // Modifier component of the current release
+	Modifier                 = ""     // Modifier component of the current release
 	DefaultSnapshotGitBranch = "main" // Branch of erigontech/erigon-snapshot to use in OtterSync
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -30,9 +30,9 @@ var (
 // see https://calver.org
 const (
 	Major                    = 3      // Major version component of the current release
-	Minor                    = 5      // Minor version component of the current release
+	Minor                    = 6      // Minor version component of the current release
 	Micro                    = 0      // Micro version component of the current release
-	Modifier                 = ""     // Modifier component of the current release
+	Modifier                 = "beta" // Modifier component of the current release
 	DefaultSnapshotGitBranch = "main" // Branch of erigontech/erigon-snapshot to use in OtterSync
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -170,6 +170,7 @@ var (
 			LisovoBlock:       big.NewInt(0),
 			LisovoProBlock:    big.NewInt(0),
 			GiuglianoBlock:    big.NewInt(0),
+			ChicagoBlock:      big.NewInt(0),
 		},
 	}
 
@@ -222,6 +223,8 @@ type BorConfig interface {
 	GetLisovoProBlock() *big.Int
 	IsGiugliano(num uint64) bool
 	GetGiuglianoBlock() *big.Int
+	IsChicago(num uint64) bool
+	GetChicagoBlock() *big.Int
 	StateReceiverContractAddress() common.Address
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
@@ -240,7 +243,7 @@ func (c *Config) String() string {
 	engine := c.getEngine()
 
 	if c.Bor != nil {
-		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Rio: %v, Madhugiri: %v, MadhugiriPro: %v, Lisovo: %v, LisovoPro: %v, Giugliano: %v, Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Rio: %v, Madhugiri: %v, MadhugiriPro: %v, Lisovo: %v, LisovoPro: %v, Giugliano: %v, Chicago: %v, Engine: %v}",
 			c.ChainID,
 			c.Bor.GetAgraBlock(),
 			c.Bor.GetNapoliBlock(),
@@ -252,6 +255,7 @@ func (c *Config) String() string {
 			c.Bor.GetLisovoBlock(),
 			c.Bor.GetLisovoProBlock(),
 			c.Bor.GetGiuglianoBlock(),
+			c.Bor.GetChicagoBlock(),
 			engine,
 		)
 	}
@@ -402,6 +406,10 @@ func (c *Config) IsLisovoPro(num uint64) bool {
 
 func (c *Config) IsGiugliano(num uint64) bool {
 	return (c != nil) && (c.Bor != nil) && c.Bor.IsGiugliano(num)
+}
+
+func (c *Config) IsChicago(num uint64) bool {
+	return (c != nil) && (c.Bor != nil) && c.Bor.IsChicago(num)
 }
 
 // IsCancun returns whether time is either equal to the Cancun fork time or greater.
@@ -784,6 +792,7 @@ type Rules struct {
 	IsLisovo                                                         bool
 	IsLisovoPro                                                      bool
 	IsGiugliano                                                      bool
+	IsChicago                                                        bool
 	IsAura                                                           bool
 }
 

--- a/execution/chain/params/protocol.go
+++ b/execution/chain/params/protocol.go
@@ -71,11 +71,21 @@ const (
 	ColdSloadCostEIP2929         = uint64(2100) // COLD_SLOAD_COST
 	WarmStorageReadCostEIP2929   = uint64(100)  // WARM_STORAGE_READ_COST
 
+	// PIP-88: cold-storage repricing for the Chicago hard fork.
+	// EIP-2929 uses a single COLD_SLOAD_COST for both SLOAD and SSTORE.
+	// PIP-88 splits it into two so SLOAD and SSTORE can scale independently.
+	ColdSloadCostPIP88  uint64 = 5460 // 2100 * 2.6 - COLD_SLOAD_COST surcharge
+	ColdSstoreCostPIP88 uint64 = 2940 // 2100 * 1.4 - COLD_SSTORE_COST surcharge
+
 	// In EIP-2200: SstoreResetGas was 5000.
 	// In EIP-2929: SstoreResetGas was changed to '5000 - COLD_SLOAD_COST'.
 	// In EIP-3529: SSTORE_CLEARS_SCHEDULE is defined as SSTORE_RESET_GAS + ACCESS_LIST_STORAGE_KEY_COST
 	// Which becomes: 5000 - 2100 + 1900 = 4800
 	SstoreClearsScheduleRefundEIP3529 = SstoreResetGasEIP2200 - ColdSloadCostEIP2929 + TxAccessListStorageKeyGas
+
+	// PIP-88: SSTORE_CLEARS_SCHEDULE recomputed against the PIP-88 COLD_SSTORE_COST.
+	// Which becomes: 5000 - 2940 + 1900 = 3960.
+	SstoreClearsScheduleRefundPIP88 uint64 = SstoreResetGasEIP2200 - ColdSstoreCostPIP88 + TxAccessListStorageKeyGas
 
 	JumpdestGas   uint64 = 1     // Once per JUMPDEST operation.
 	EpochDuration uint64 = 30000 // Duration between proof-of-work epochs.
@@ -195,6 +205,24 @@ const (
 	// PIP-27: secp256r1 elliptic curve signature verifier gas price
 	P256VerifyGas        uint64 = 3450
 	P256VerifyGasEIP7951 uint64 = 6900
+
+	// PIP-88: precompile gas repricing activated by the Chicago hard fork.
+
+	GFROUNDPIP88 uint64 = 22 // PIP-88 GFROUND for blake2F operation
+
+	Bn254AddGasIstanbulPIP88             uint64 = 540   // 150 * 3.6
+	Bn254ScalarMulGasIstanbulPIP88       uint64 = 12600 // 6000 * 2.1
+	Bn254PairingBaseGasIstanbulPIP88     uint64 = 67500 // 45000 * 1.5
+	Bn254PairingPerPointGasIstanbulPIP88 uint64 = 51000 // 34000 * 1.5
+
+	Bls12381G1AddGasPIP88          uint64 = 1050   // 375 * 2.8
+	Bls12381G1MulGasPIP88          uint64 = 73200  // 12000 * 6.1 (k=1)
+	Bls12381G2AddGasPIP88          uint64 = 1620   // 600 * 2.7
+	Bls12381G2MulGasPIP88          uint64 = 144000 // 22500 * 6.4 (k=1)
+	Bls12381PairingBaseGasPIP88    uint64 = 109330 // 37700 * 2.9
+	Bls12381PairingPerPairGasPIP88 uint64 = 94540  // 32600 * 2.9
+	Bls12381MapFpToG1GasPIP88      uint64 = 15400  // 5500 * 2.8
+	Bls12381MapFp2ToG2GasPIP88     uint64 = 66640  // 23800 * 2.8
 
 	// EIP-2935: Historical block hashes in state
 	BlockHashHistoryServeWindow uint64 = 8191

--- a/p2p/forkid/forkid.go
+++ b/p2p/forkid/forkid.go
@@ -260,6 +260,18 @@ func GatherForks(config *chain.Config, genesisTime uint64) (heightForks []uint64
 		if config.Bor.GetBhilaiBlock() != nil {
 			heightForks = append(heightForks, config.Bor.GetBhilaiBlock().Uint64())
 		}
+		if config.Bor.GetLisovoBlock() != nil {
+			heightForks = append(heightForks, config.Bor.GetLisovoBlock().Uint64())
+		}
+		if config.Bor.GetLisovoProBlock() != nil {
+			heightForks = append(heightForks, config.Bor.GetLisovoProBlock().Uint64())
+		}
+		if config.Bor.GetGiuglianoBlock() != nil {
+			heightForks = append(heightForks, config.Bor.GetGiuglianoBlock().Uint64())
+		}
+		if config.Bor.GetChicagoBlock() != nil {
+			heightForks = append(heightForks, config.Bor.GetChicagoBlock().Uint64())
+		}
 	}
 
 	// Sort the fork block numbers & times to permit chronological XOR

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -52,6 +52,7 @@ type BorConfig struct {
 	LisovoBlock       *big.Int `json:"lisovoBlock"`       // Lisovo switch block (nil = no fork, 0 = already on Lisovo)
 	LisovoProBlock    *big.Int `json:"lisovoProBlock"`    // LisovoPro switch block (nil = no fork, 0 = already on LisovoPro)
 	GiuglianoBlock    *big.Int `json:"giuglianoBlock"`    // Giugliano switch block (nil = no fork, 0 = already on Giugliano)
+	ChicagoBlock      *big.Int `json:"chicagoBlock"`      // Chicago switch block (nil = no fork, 0 = already on Chicago)
 
 	StateSyncConfirmationDelay map[string]uint64         `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 	Coinbase                   map[string]common.Address `json:"coinbase"`                   // coinbase address
@@ -242,6 +243,14 @@ func (c *BorConfig) IsGiugliano(number uint64) bool {
 
 func (c *BorConfig) GetGiuglianoBlock() *big.Int {
 	return c.GiuglianoBlock
+}
+
+func (c *BorConfig) IsChicago(number uint64) bool {
+	return isForked(c.ChicagoBlock, number)
+}
+
+func (c *BorConfig) GetChicagoBlock() *big.Int {
+	return c.ChicagoBlock
 }
 
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {

--- a/polygon/chain/chainspecs/amoy.json
+++ b/polygon/chain/chainspecs/amoy.json
@@ -52,6 +52,7 @@
       "lisovoBlock": 33634700,
       "lisovoProBlock": 34062000,
       "giuglianoBlock": 35573500,
+      "chicagoBlock": 38358000,
       "blockAlloc": {
         "11865856": {
           "0000000000000000000000000000000000001001": {

--- a/polygon/chain/chainspecs/bor-mainnet.json
+++ b/polygon/chain/chainspecs/bor-mainnet.json
@@ -102,6 +102,7 @@
     "lisovoBlock": 83756500,
     "lisovoProBlock": 83756500,
     "giuglianoBlock": 85268500,
+    "chicagoBlock": 87218600,
     "coinbase": {
       "0": "0x0000000000000000000000000000000000000000",
       "77414656": "0x7Ee41D8A25641000661B1EF5E6AE8A00400466B0"


### PR DESCRIPTION
## Summary

This release includes the changes required for an upcoming hardfork (**Chicago**)

## Activation

| Network | Activation block | Target time           |
|---------|------------------|-----------------------|
| Amoy    | `38358000`       | 2026-05-14 14:00 UTC  |
| Mainnet | `87218600`       | 2026-05-21 14:00 UTC  |

## Rollout notes

- Consensus-affecting; coordinated upgrade required across the network before the activation block on each chain.
- Backward compatible up to the activation block — pre-activation behavior is unchanged.
- No configuration migration or resync required.
- Cut from `master` (hotfix-style release flow) to ship independently of `develop`'s pending content. Post-release backport `master` → `develop` will follow.

## Executed tests

Kurtosis devnets.