### PR TITLE
rpc/ethapi: stateDiff override visible to committed reads

### DIFF
--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -871,6 +871,19 @@ func (sdb *IntraBlockState) setState(addr common.Address, key common.Hash, value
 	return nil
 }
 
+// SetStateOverride seeds an account slot as if its value were already committed
+// on-chain. Intended for eth_call stateOverride.stateDiff so EIP-2200's
+// GetCommittedState read matches geth/Bor (visible to both GetState and
+// GetCommittedState). Not for execution paths.
+func (sdb *IntraBlockState) SetStateOverride(addr common.Address, key common.Hash, value uint256.Int) error {
+	stateObject, err := sdb.GetOrNewStateObject(addr)
+	if err != nil {
+		return err
+	}
+	stateObject.setCommittedStorage(key, value)
+	return nil
+}
+
 // SetStorage replaces the entire storage for the specified account with given
 // storage. This function should only be used for debugging.
 func (sdb *IntraBlockState) SetStorage(addr common.Address, storage Storage) error {

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -871,10 +871,7 @@ func (sdb *IntraBlockState) setState(addr common.Address, key common.Hash, value
 	return nil
 }
 
-// SetStateOverride seeds an account slot as if its value were already committed
-// on-chain. Intended for eth_call stateOverride.stateDiff so EIP-2200's
-// GetCommittedState read matches geth/Bor (visible to both GetState and
-// GetCommittedState). Not for execution paths.
+// SetStateOverride applies an eth_call stateDiff slot as base state. Not for block execution.
 func (sdb *IntraBlockState) SetStateOverride(addr common.Address, key common.Hash, value uint256.Int) error {
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -283,6 +283,16 @@ func (so *stateObject) setState(key common.Hash, value uint256.Int) {
 	so.dirtyStorage[key] = value
 }
 
+// setCommittedStorage seeds a slot as if its value were already on-chain.
+// EIP-2200 reads GetCommittedState for the original value; geth's stateDiff
+// override makes that read return the override (via Finalise). Erigon's
+// SetState only writes dirtyStorage, so without this the original stays 0
+// and warm-reset SSTORE drops into the dirty branch.
+func (so *stateObject) setCommittedStorage(key common.Hash, value uint256.Int) {
+	so.originStorage[key] = value
+	so.blockOriginStorage[key] = value
+}
+
 // updateStotage writes cached storage modifications into the object's storage trie.
 func (so *stateObject) updateStotage(stateWriter StateWriter) error {
 	for key, value := range so.dirtyStorage {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -286,9 +286,11 @@ func (so *stateObject) setState(key common.Hash, value uint256.Int) {
 // setCommittedStorage seeds a slot as if its value were already on-chain.
 // EIP-2200 reads GetCommittedState for the original value; geth's stateDiff
 // override makes that read return the override (via Finalise). Erigon's
-// SetState only writes dirtyStorage, so without this the original stays 0
-// and warm-reset SSTORE drops into the dirty branch.
+// SetState only writes dirtyStorage, so without this the original stays 0.
+// Clear any pending dirty value as well: stateDiff is a base-state override
+// and must replace replay-produced current storage too.
 func (so *stateObject) setCommittedStorage(key common.Hash, value uint256.Int) {
+	delete(so.dirtyStorage, key)
 	so.originStorage[key] = value
 	so.blockOriginStorage[key] = value
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -283,13 +283,9 @@ func (so *stateObject) setState(key common.Hash, value uint256.Int) {
 	so.dirtyStorage[key] = value
 }
 
-// setCommittedStorage seeds a slot as if its value were already on-chain.
-// EIP-2200 reads GetCommittedState for the original value; geth's stateDiff
-// override makes that read return the override (via Finalise). Erigon's
-// SetState only writes dirtyStorage, so without this the original stays 0.
-// Clear any pending dirty value as well: stateDiff is a base-state override
-// and must replace replay-produced current storage too.
+// setCommittedStorage makes stateDiff visible as both current and original storage.
 func (so *stateObject) setCommittedStorage(key common.Hash, value uint256.Int) {
+	// Drop replayed writes so the override wins after callMany-style replay.
 	delete(so.dirtyStorage, key)
 	so.originStorage[key] = value
 	so.blockOriginStorage[key] = value

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -147,6 +147,39 @@ func TestSnapshot(t *testing.T) {
 	require.Equal(t, uint256.Int{}, value)
 }
 
+func TestSetStateOverrideReplacesDirtyStorage(t *testing.T) {
+	t.Parallel()
+	_, tx, domains := NewTestRwTx(t)
+
+	err := rawdbv3.TxNums.Append(tx, 1, 1)
+	require.NoError(t, err)
+
+	state := New(NewReaderV3(domains.AsGetter(tx)))
+
+	addr := toAddr([]byte("aa"))
+	key := common.BigToHash(uint256.NewInt(1).ToBig())
+	replayed := *uint256.NewInt(1)
+	override := *uint256.NewInt(2)
+
+	require.NoError(t, state.SetState(addr, key, replayed))
+	require.NoError(t, state.FinalizeTx(&chain.Rules{}, NewNoopWriter()))
+
+	var value uint256.Int
+	require.NoError(t, state.GetState(addr, key, &value))
+	require.Equal(t, replayed, value)
+
+	require.NoError(t, state.SetStateOverride(addr, key, override))
+	require.NoError(t, state.GetState(addr, key, &value))
+	require.Equal(t, override, value)
+	require.NoError(t, state.GetCommittedState(addr, key, &value))
+	require.Equal(t, override, value)
+
+	obj, err := state.getStateObject(addr)
+	require.NoError(t, err)
+	_, dirty := obj.dirtyStorage[key]
+	require.False(t, dirty)
+}
+
 func TestSnapshotEmpty(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)

--- a/core/vm/runtime/state_override_warm_reset_test.go
+++ b/core/vm/runtime/state_override_warm_reset_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package runtime
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon/core/state"
+	"github.com/erigontech/erigon/core/vm"
+)
+
+// TestEthCallStateDiffOverride_WarmResetSSTORE reproduces the warm-reset
+// case from pos-e2e tests/execution-specs/evm/pip88-erigon-sload-sstore-chicago-gas.bats
+// in-process, contrasting the broken eth_call stateDiff path (raw SetState)
+// against the fixed path (SetStateOverride).
+//
+// The bytecode warms slot 1 with an SLOAD, then SSTOREs slot 1 := 2 and
+// returns gas-before minus gas-after. EIP-2200 inspects both GetState (current)
+// and GetCommittedState (original):
+//   - Broken: only dirtyStorage carries the override, so original=0, current=1.
+//     The "dirty update" branch fires → SSTORE costs WarmStorageReadCostEIP2929 (100).
+//   - Fixed: originStorage also carries the override, so original=current=1,
+//     value=2. The "reset existing slot" branch fires →
+//     SSTORE costs SstoreResetGasEIP2200 - ColdSloadCostEIP2929 (2900).
+//
+// Inner sandwich (PUSH PUSH SSTORE GAS) adds 3+3+X+2 around SSTORE cost X.
+// Bor reports the reset value because override.go calls statedb.Finalise after
+// applying the diff, which promotes dirty → pending storage and makes
+// GetCommittedState return it. Erigon's IntraBlockState has no equivalent
+// public path, so we seed originStorage directly.
+func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
+	t.Parallel()
+
+	// 60 01     PUSH1 0x01
+	// 54        SLOAD            warms slot 1 into the access list
+	// 50        POP
+	// 5a        GAS              push gas_before
+	// 60 02     PUSH1 0x02
+	// 60 01     PUSH1 0x01
+	// 55        SSTORE           slot 1 := 2
+	// 5a        GAS              push gas_after
+	// 90        SWAP1
+	// 03        SUB              consumed = gas_before - gas_after
+	// 60 00     PUSH1 0x00
+	// 52        MSTORE           mem[0:32] = consumed
+	// 60 20     PUSH1 0x20
+	// 60 00     PUSH1 0x00
+	// f3       RETURN           return mem[0:32]
+	code := []byte{
+		byte(vm.PUSH1), 0x01,
+		byte(vm.SLOAD),
+		byte(vm.POP),
+		byte(vm.GAS),
+		byte(vm.PUSH1), 0x02,
+		byte(vm.PUSH1), 0x01,
+		byte(vm.SSTORE),
+		byte(vm.GAS),
+		byte(vm.SWAP1),
+		byte(vm.SUB),
+		byte(vm.PUSH1), 0x00,
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 0x20,
+		byte(vm.PUSH1), 0x00,
+		byte(vm.RETURN),
+	}
+
+	addr := common.HexToAddress("0xaa")
+	slot := common.BigToHash(uint256.NewInt(1).ToBig())
+	one := *uint256.NewInt(1)
+
+	// EIP-2200 reset path: SstoreResetGasEIP2200 - ColdSloadCostEIP2929 = 5000 - 2100.
+	const sstoreResetWarm = 2900
+	// EIP-2200 dirty update branch: WarmStorageReadCostEIP2929.
+	const sstoreDirty = 100
+	// PUSH1 (3) + PUSH1 (3) + GAS (2) framing around the inner SSTORE.
+	const sandwich = 3 + 3 + 2
+
+	measure := func(seed func(s *state.IntraBlockState)) uint64 {
+		db := testTemporalDB(t)
+		tx, domains := testTemporalTxSD(t, db)
+		s := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+		s.SetCode(addr, code)
+		seed(s)
+		ret, _, err := Call(addr, nil, &Config{State: s})
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+		if len(ret) != 32 {
+			t.Fatalf("expected 32-byte return, got %d bytes", len(ret))
+		}
+		// Return value is a 32-byte big-endian uint; consumed gas comfortably fits in 64 bits.
+		return binary.BigEndian.Uint64(ret[24:])
+	}
+
+	t.Run("broken/raw SetState matches Erigon pre-fix", func(t *testing.T) {
+		got := measure(func(s *state.IntraBlockState) {
+			if err := s.SetState(addr, slot, one); err != nil {
+				t.Fatalf("SetState: %v", err)
+			}
+		})
+		want := uint64(sstoreDirty + sandwich)
+		if got != want {
+			t.Fatalf("dirty-branch gas: got %d, want %d", got, want)
+		}
+	})
+
+	t.Run("fixed/SetStateOverride matches Bor/geth", func(t *testing.T) {
+		got := measure(func(s *state.IntraBlockState) {
+			if err := s.SetStateOverride(addr, slot, one); err != nil {
+				t.Fatalf("SetStateOverride: %v", err)
+			}
+		})
+		want := uint64(sstoreResetWarm + sandwich)
+		if got != want {
+			t.Fatalf("reset-branch gas: got %d, want %d", got, want)
+		}
+	})
+
+	t.Run("delta is the EIP-2200 reset/dirty spread", func(t *testing.T) {
+		broken := measure(func(s *state.IntraBlockState) {
+			_ = s.SetState(addr, slot, one)
+		})
+		fixed := measure(func(s *state.IntraBlockState) {
+			_ = s.SetStateOverride(addr, slot, one)
+		})
+		if fixed-broken != sstoreResetWarm-sstoreDirty {
+			t.Fatalf("expected reset-vs-dirty spread %d, got %d (broken=%d fixed=%d)",
+				sstoreResetWarm-sstoreDirty, fixed-broken, broken, fixed)
+		}
+	})
+}

--- a/core/vm/runtime/state_override_warm_reset_test.go
+++ b/core/vm/runtime/state_override_warm_reset_test.go
@@ -147,3 +147,71 @@ func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
 		}
 	})
 }
+
+// TestEthCallStateDiffOverride_BeatsReplayDirty pins the eth_callMany
+// behavior: when an override is applied after a replayed transaction has
+// already written the same slot, the override must win for both reads.
+// FinalizeTx writes dirtyStorage through to the writer but does not clear
+// it, so without an explicit dirty-clear in setCommittedStorage the replay
+// value would still shadow GetState — only GetCommittedState would change.
+func TestEthCallStateDiffOverride_BeatsReplayDirty(t *testing.T) {
+	t.Parallel()
+
+	// SLOAD slot 1, return the 32-byte value.
+	code := []byte{
+		byte(vm.PUSH1), 0x01,
+		byte(vm.SLOAD),
+		byte(vm.PUSH1), 0x00,
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 0x20,
+		byte(vm.PUSH1), 0x00,
+		byte(vm.RETURN),
+	}
+	addr := common.HexToAddress("0xaa")
+	slot := common.BigToHash(uint256.NewInt(1).ToBig())
+	replay := *uint256.NewInt(0xdead)
+	override := *uint256.NewInt(0x42)
+
+	db := testTemporalDB(t)
+	tx, domains := testTemporalTxSD(t, db)
+	s := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	s.SetCode(addr, code)
+
+	// Simulate a replayed tx writing slot 1.
+	if err := s.SetState(addr, slot, replay); err != nil {
+		t.Fatalf("seed replay: %v", err)
+	}
+	// stateOverride applied after replay.
+	if err := s.SetStateOverride(addr, slot, override); err != nil {
+		t.Fatalf("SetStateOverride: %v", err)
+	}
+
+	// Direct read: GetCommittedState and GetState must both see the override.
+	var got uint256.Int
+	if err := s.GetCommittedState(addr, slot, &got); err != nil {
+		t.Fatalf("GetCommittedState: %v", err)
+	}
+	if got.Cmp(&override) != 0 {
+		t.Fatalf("GetCommittedState: got %s, want %s", got.Hex(), override.Hex())
+	}
+	if err := s.GetState(addr, slot, &got); err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if got.Cmp(&override) != 0 {
+		t.Fatalf("GetState: got %s, want %s (replay leaked through dirtyStorage)", got.Hex(), override.Hex())
+	}
+
+	// EVM-level read via SLOAD must match too.
+	ret, _, err := Call(addr, nil, &Config{State: s})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if len(ret) != 32 {
+		t.Fatalf("expected 32-byte return, got %d", len(ret))
+	}
+	var sload uint256.Int
+	sload.SetBytes(ret)
+	if sload.Cmp(&override) != 0 {
+		t.Fatalf("SLOAD: got %s, want %s (replay leaked through dirtyStorage)", sload.Hex(), override.Hex())
+	}
+}

--- a/core/vm/runtime/state_override_warm_reset_test.go
+++ b/core/vm/runtime/state_override_warm_reset_test.go
@@ -27,43 +27,10 @@ import (
 	"github.com/erigontech/erigon/core/vm"
 )
 
-// TestEthCallStateDiffOverride_WarmResetSSTORE reproduces the warm-reset
-// case from pos-e2e tests/execution-specs/evm/pip88-erigon-sload-sstore-chicago-gas.bats
-// in-process, contrasting the broken eth_call stateDiff path (raw SetState)
-// against the fixed path (SetStateOverride).
-//
-// The bytecode warms slot 1 with an SLOAD, then SSTOREs slot 1 := 2 and
-// returns gas-before minus gas-after. EIP-2200 inspects both GetState (current)
-// and GetCommittedState (original):
-//   - Broken: only dirtyStorage carries the override, so original=0, current=1.
-//     The "dirty update" branch fires → SSTORE costs WarmStorageReadCostEIP2929 (100).
-//   - Fixed: originStorage also carries the override, so original=current=1,
-//     value=2. The "reset existing slot" branch fires →
-//     SSTORE costs SstoreResetGasEIP2200 - ColdSloadCostEIP2929 (2900).
-//
-// Inner sandwich (PUSH PUSH SSTORE GAS) adds 3+3+X+2 around SSTORE cost X.
-// Bor reports the reset value because override.go calls statedb.Finalise after
-// applying the diff, which promotes dirty → pending storage and makes
-// GetCommittedState return it. Erigon's IntraBlockState has no equivalent
-// public path, so we seed originStorage directly.
 func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
 	t.Parallel()
 
-	// 60 01     PUSH1 0x01
-	// 54        SLOAD            warms slot 1 into the access list
-	// 50        POP
-	// 5a        GAS              push gas_before
-	// 60 02     PUSH1 0x02
-	// 60 01     PUSH1 0x01
-	// 55        SSTORE           slot 1 := 2
-	// 5a        GAS              push gas_after
-	// 90        SWAP1
-	// 03        SUB              consumed = gas_before - gas_after
-	// 60 00     PUSH1 0x00
-	// 52        MSTORE           mem[0:32] = consumed
-	// 60 20     PUSH1 0x20
-	// 60 00     PUSH1 0x00
-	// f3       RETURN           return mem[0:32]
+	// Warm slot 1, SSTORE slot 1 := 2, and return the gas delta around SSTORE.
 	code := []byte{
 		byte(vm.PUSH1), 0x01,
 		byte(vm.SLOAD),
@@ -86,12 +53,10 @@ func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
 	slot := common.BigToHash(uint256.NewInt(1).ToBig())
 	one := *uint256.NewInt(1)
 
-	// EIP-2200 reset path: SstoreResetGasEIP2200 - ColdSloadCostEIP2929 = 5000 - 2100.
-	const sstoreResetWarm = 2900
-	// EIP-2200 dirty update branch: WarmStorageReadCostEIP2929.
-	const sstoreDirty = 100
-	// PUSH1 (3) + PUSH1 (3) + GAS (2) framing around the inner SSTORE.
-	const sandwich = 3 + 3 + 2
+	// stateDiff must be visible as the original value, or SSTORE takes the cheap dirty path.
+	const sstoreResetWarm = 2900 // EIP-2200 reset (warm): SstoreResetGas - ColdSloadCost.
+	const sstoreDirty = 100      // EIP-2200 dirty update: WarmStorageReadCost.
+	const sandwich = 3 + 3 + 2   // PUSH1 + PUSH1 + GAS around the inner SSTORE.
 
 	measure := func(seed func(s *state.IntraBlockState)) uint64 {
 		db := testTemporalDB(t)
@@ -101,12 +66,11 @@ func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
 		seed(s)
 		ret, _, err := Call(addr, nil, &Config{State: s})
 		if err != nil {
-			t.Fatalf("Call failed: %v", err)
+			t.Fatalf("Call: %v", err)
 		}
 		if len(ret) != 32 {
-			t.Fatalf("expected 32-byte return, got %d bytes", len(ret))
+			t.Fatalf("ret len: %d", len(ret))
 		}
-		// Return value is a 32-byte big-endian uint; consumed gas comfortably fits in 64 bits.
 		return binary.BigEndian.Uint64(ret[24:])
 	}
 
@@ -116,9 +80,8 @@ func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
 				t.Fatalf("SetState: %v", err)
 			}
 		})
-		want := uint64(sstoreDirty + sandwich)
-		if got != want {
-			t.Fatalf("dirty-branch gas: got %d, want %d", got, want)
+		if want := uint64(sstoreDirty + sandwich); got != want {
+			t.Fatalf("got %d, want %d", got, want)
 		}
 	})
 
@@ -128,36 +91,26 @@ func TestEthCallStateDiffOverride_WarmResetSSTORE(t *testing.T) {
 				t.Fatalf("SetStateOverride: %v", err)
 			}
 		})
-		want := uint64(sstoreResetWarm + sandwich)
-		if got != want {
-			t.Fatalf("reset-branch gas: got %d, want %d", got, want)
+		if want := uint64(sstoreResetWarm + sandwich); got != want {
+			t.Fatalf("got %d, want %d", got, want)
 		}
 	})
 
 	t.Run("delta is the EIP-2200 reset/dirty spread", func(t *testing.T) {
-		broken := measure(func(s *state.IntraBlockState) {
-			_ = s.SetState(addr, slot, one)
-		})
-		fixed := measure(func(s *state.IntraBlockState) {
-			_ = s.SetStateOverride(addr, slot, one)
-		})
+		broken := measure(func(s *state.IntraBlockState) { _ = s.SetState(addr, slot, one) })
+		fixed := measure(func(s *state.IntraBlockState) { _ = s.SetStateOverride(addr, slot, one) })
 		if fixed-broken != sstoreResetWarm-sstoreDirty {
-			t.Fatalf("expected reset-vs-dirty spread %d, got %d (broken=%d fixed=%d)",
-				sstoreResetWarm-sstoreDirty, fixed-broken, broken, fixed)
+			t.Fatalf("spread %d, want %d (broken=%d fixed=%d)",
+				fixed-broken, sstoreResetWarm-sstoreDirty, broken, fixed)
 		}
 	})
 }
 
-// TestEthCallStateDiffOverride_BeatsReplayDirty pins the eth_callMany
-// behavior: when an override is applied after a replayed transaction has
-// already written the same slot, the override must win for both reads.
-// FinalizeTx writes dirtyStorage through to the writer but does not clear
-// it, so without an explicit dirty-clear in setCommittedStorage the replay
-// value would still shadow GetState — only GetCommittedState would change.
+// Regression: stateDiff must win over a replay-dirtied slot.
+// eth_callMany applies overrides after replay, and FinalizeTx leaves dirtyStorage in memory.
 func TestEthCallStateDiffOverride_BeatsReplayDirty(t *testing.T) {
 	t.Parallel()
 
-	// SLOAD slot 1, return the 32-byte value.
 	code := []byte{
 		byte(vm.PUSH1), 0x01,
 		byte(vm.SLOAD),
@@ -177,16 +130,13 @@ func TestEthCallStateDiffOverride_BeatsReplayDirty(t *testing.T) {
 	s := state.New(state.NewReaderV3(domains.AsGetter(tx)))
 	s.SetCode(addr, code)
 
-	// Simulate a replayed tx writing slot 1.
 	if err := s.SetState(addr, slot, replay); err != nil {
 		t.Fatalf("seed replay: %v", err)
 	}
-	// stateOverride applied after replay.
 	if err := s.SetStateOverride(addr, slot, override); err != nil {
 		t.Fatalf("SetStateOverride: %v", err)
 	}
 
-	// Direct read: GetCommittedState and GetState must both see the override.
 	var got uint256.Int
 	if err := s.GetCommittedState(addr, slot, &got); err != nil {
 		t.Fatalf("GetCommittedState: %v", err)
@@ -198,20 +148,19 @@ func TestEthCallStateDiffOverride_BeatsReplayDirty(t *testing.T) {
 		t.Fatalf("GetState: %v", err)
 	}
 	if got.Cmp(&override) != 0 {
-		t.Fatalf("GetState: got %s, want %s (replay leaked through dirtyStorage)", got.Hex(), override.Hex())
+		t.Fatalf("GetState: got %s, want %s", got.Hex(), override.Hex())
 	}
 
-	// EVM-level read via SLOAD must match too.
 	ret, _, err := Call(addr, nil, &Config{State: s})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
 	if len(ret) != 32 {
-		t.Fatalf("expected 32-byte return, got %d", len(ret))
+		t.Fatalf("ret len: %d", len(ret))
 	}
 	var sload uint256.Int
 	sload.SetBytes(ret)
 	if sload.Cmp(&override) != 0 {
-		t.Fatalf("SLOAD: got %s, want %s (replay leaked through dirtyStorage)", sload.Hex(), override.Hex())
+		t.Fatalf("SLOAD: got %s, want %s", sload.Hex(), override.Hex())
 	}
 }

--- a/rpc/ethapi/state_overrides.go
+++ b/rpc/ethapi/state_overrides.go
@@ -61,12 +61,16 @@ func (overrides *StateOverrides) Override(state *state.IntraBlockState) error {
 			}
 			state.SetStorage(addr, intState)
 		}
-		// Apply state diff into specified accounts.
+		// Apply state diff into specified accounts. Use SetStateOverride so the
+		// value is also visible to GetCommittedState — without this, EIP-2200
+		// SSTORE gas accounting reads original=0 and diverges from Bor/geth.
 		if account.StateDiff != nil {
 			for key, value := range *account.StateDiff {
 				key := key
 				intValue := new(uint256.Int).SetBytes32(value.Bytes())
-				state.SetState(addr, key, *intValue)
+				if err := state.SetStateOverride(addr, key, *intValue); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/rpc/ethapi/state_overrides.go
+++ b/rpc/ethapi/state_overrides.go
@@ -61,9 +61,7 @@ func (overrides *StateOverrides) Override(state *state.IntraBlockState) error {
 			}
 			state.SetStorage(addr, intState)
 		}
-		// Apply state diff into specified accounts. Use SetStateOverride so the
-		// value is also visible to GetCommittedState — without this, EIP-2200
-		// SSTORE gas accounting reads original=0 and diverges from Bor/geth.
+		// Apply stateDiff as base storage so SSTORE sees the overridden original value.
 		if account.StateDiff != nil {
 			for key, value := range *account.StateDiff {
 				key := key


### PR DESCRIPTION
## Description

Erigon's eth_call stateOverride.stateDiff only wrote dirtyStorage on the affected stateObject. GetCommittedState reads originStorage, so the override was invisible to EIP-2200's original-value read: SSTORE warm reset fell into the dirty branch (100 gas) instead of reset (2900 gas on Berlin onward, 2060 post-PIP-88). Bor doesn't hit this because their override applies SetState then statedb.Finalise, which promotes dirty into pending so GetCommittedState returns it.

Add IntraBlockState.SetStateOverride (writes both origin and dirty via stateObject.setCommittedStorage) and route the stateDiff loop through it. Mirrors Bor's post-Finalise semantics with a smaller surface change than porting Finalise itself, which would require chainRules and a StateWriter the override path can't supply.