### PR TITLE
polygon/bridge: derive state-sync window from gated Heimdall query

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -29,11 +29,11 @@ var (
 
 // see https://calver.org
 const (
-	Major                    = 3      // Major version component of the current release
-	Minor                    = 6      // Minor version component of the current release
-	Micro                    = 1      // Micro version component of the current release
-	Modifier                 = "beta" // Modifier component of the current release
-	DefaultSnapshotGitBranch = "main" // Branch of erigontech/erigon-snapshot to use in OtterSync
+	Major                    = 3       // Major version component of the current release
+	Minor                    = 6       // Minor version component of the current release
+	Micro                    = 1       // Micro version component of the current release
+	Modifier                 = "beta2" // Modifier component of the current release
+	DefaultSnapshotGitBranch = "main"  // Branch of erigontech/erigon-snapshot to use in OtterSync
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"
 	ClientName               = "erigon"

--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -420,7 +420,10 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 				return err
 			}
 
-			endId, err = s.store.LastEventIdWithinWindow(ctx, startId, time.Unix(int64(toTime), 0))
+			// Read the window boundary live from Heimdall (the same gated
+			// clerk/time query bor uses) rather than scanning the local event
+			// store, which holds not-yet-stable events Heimdall still withholds.
+			endId, err = s.lastEventIdWithinWindowFromHeimdall(ctx, startId, time.Unix(int64(toTime), 0))
 			if err != nil {
 				return err
 			}
@@ -529,6 +532,34 @@ func (s *Service) blockEventsTimeWindowEnd(last ProcessedBlockInfo, blockNum uin
 	}
 
 	return last.BlockTime, nil
+}
+
+// lastEventIdWithinWindowFromHeimdall returns the id of the last state-sync
+// event in [fromId, toTime), read live from Heimdall's clerk/time endpoint the
+// same way bor's CommitStates does. bor consumes Heimdall's server-side
+// stability gate, which withholds the most-recent event group until it is
+// confirmed; re-deriving the window from the local event store sees those
+// not-yet-stable events and over-includes them, diverging from the network and
+// producing a bad block on import. Returns 0 when the window contains no events.
+func (s *Service) lastEventIdWithinWindowFromHeimdall(ctx context.Context, fromId uint64, toTime time.Time) (uint64, error) {
+	events, err := s.eventFetcher.FetchStateSyncEvents(ctx, fromId, toTime, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	var eventId uint64
+	// Stop at the first id gap or first event at/after toTime, matching the
+	// sequential, strict-before semantics bor enforces in CommitStates.
+	expected := fromId
+	for _, event := range events {
+		if event.ID != expected || !event.Time.Before(toTime) {
+			break
+		}
+		eventId = event.ID
+		expected++
+	}
+
+	return eventId, nil
 }
 
 func (s *Service) waitForScraper(ctx context.Context, toTime uint64) error {

--- a/polygon/bridge/service_test.go
+++ b/polygon/bridge/service_test.go
@@ -82,6 +82,24 @@ func getBlocks(t *testing.T, numBlocks int) []*types.Block {
 	return blocks
 }
 
+// expectHeimdallEvents wires the mock event fetcher to behave like Heimdall's
+// clerk/time endpoint: every call (the scraper and the live window boundary
+// query in ProcessNewBlocks) returns the events with id >= fromID.
+func expectHeimdallEvents(client *MockClient, events []*EventRecordWithTime) {
+	client.EXPECT().
+		FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, fromID uint64, _ time.Time, _ int) ([]*EventRecordWithTime, error) {
+			res := make([]*EventRecordWithTime, 0, len(events))
+			for _, e := range events {
+				if e.ID >= fromID {
+					res = append(res, e)
+				}
+			}
+			return res, nil
+		}).
+		AnyTimes()
+}
+
 func TestService(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -134,8 +152,7 @@ func TestService(t *testing.T) {
 
 	events := []*EventRecordWithTime{event1, event2, event3, event4}
 
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(events, nil).Times(1)
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*EventRecordWithTime{}, nil).AnyTimes()
+	expectHeimdallEvents(heimdallClient, events)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -251,8 +268,7 @@ func TestService_Unwind(t *testing.T) {
 
 	events := []*EventRecordWithTime{event1, event2, event3, event4}
 
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(events, nil).Times(1)
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*EventRecordWithTime{}, nil).AnyTimes()
+	expectHeimdallEvents(heimdallClient, events)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -367,8 +383,7 @@ func setupOverrideTest(t *testing.T, ctx context.Context, borConfig borcfg.BorCo
 
 	events := []*EventRecordWithTime{event1, event2, event3, event4, event5, event6}
 
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(events, nil).Times(1)
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*EventRecordWithTime{}, nil).AnyTimes()
+	expectHeimdallEvents(heimdallClient, events)
 	wg.Add(1)
 
 	go func(bridge *Service) {
@@ -514,8 +529,7 @@ func TestReaderEventsWithinTime(t *testing.T) {
 
 	events := []*EventRecordWithTime{event1, event2, event3, event4}
 
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(events, nil).Times(1)
-	heimdallClient.EXPECT().FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*EventRecordWithTime{}, nil).AnyTimes()
+	expectHeimdallEvents(heimdallClient, events)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -567,6 +581,98 @@ func TestReaderEventsWithinTime(t *testing.T) {
 	res, err = b.EventsWithinTime(ctx, time.Unix(500, 0), time.Unix(600, 0))
 	require.Empty(t, res)
 	require.NoError(t, err)
+
+	cancel()
+	wg.Wait()
+}
+
+// TestService_ProcessNewBlocksGatesUnstableEvents is a regression test for the
+// state-sync over-inclusion bug: an event can already be in the local store
+// (the scraper runs ahead of the tip) while Heimdall's clerk/time stability
+// gate still withholds it for a given window. ProcessNewBlocks must take the
+// window boundary from the live, gated Heimdall response rather than from a
+// scan of the store, otherwise it includes the not-yet-stable event and
+// diverges from bor, producing a bad block on import.
+func TestService_ProcessNewBlocksGatesUnstableEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	borConfig := borcfg.BorConfig{
+		Sprint:                     map[string]uint64{"0": 2},
+		StateReceiverContract:      "0x0000000000000000000000000000000000001001",
+		IndoreBlock:                big.NewInt(0),
+		StateSyncConfirmationDelay: map[string]uint64{"0": 1},
+	}
+	heimdallClient, b := setup(t, borConfig)
+
+	event1 := &EventRecordWithTime{
+		EventRecord: EventRecord{ID: 1, ChainID: "80002", Data: hexutil.MustDecode("0x01")},
+		Time:        time.Unix(50, 0),
+	}
+	event1Data, err := event1.MarshallBytes()
+	require.NoError(t, err)
+	// event2 lies inside block 2's window (time 80 < toTime 99) but Heimdall
+	// withholds it until it stabilises, modelled here as window end >= 150.
+	event2 := &EventRecordWithTime{
+		EventRecord: EventRecord{ID: 2, ChainID: "80002", Data: hexutil.MustDecode("0x02")},
+		Time:        time.Unix(80, 0),
+	}
+	event2Data, err := event2.MarshallBytes()
+	require.NoError(t, err)
+	events := []*EventRecordWithTime{event1, event2}
+
+	const gateReleaseToTime = 150
+	heimdallClient.EXPECT().
+		FetchStateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, fromID uint64, to time.Time, _ int) ([]*EventRecordWithTime, error) {
+			res := make([]*EventRecordWithTime, 0, len(events))
+			for _, e := range events {
+				if e.ID < fromID {
+					continue
+				}
+				// Stability gate: event2 is not released for a historical window
+				// until the window end reaches gateReleaseToTime. The scraper
+				// queries with to ~= now, so it always sees event2 and the store
+				// holds it - exactly the condition that tripped the bug.
+				if e.ID == 2 && to.Unix() < gateReleaseToTime {
+					continue
+				}
+				res = append(res, e)
+			}
+			return res, nil
+		}).
+		AnyTimes()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(bridge *Service) {
+		defer wg.Done()
+		if err := bridge.Run(ctx); err != nil && !errors.Is(err, ctx.Err()) {
+			t.Error(err)
+		}
+	}(b)
+
+	require.NoError(t, b.store.Prepare(ctx))
+
+	genesis := types.NewBlockWithHeader(&types.Header{Time: 1, Number: big.NewInt(0)})
+	require.NoError(t, b.ReplayInitialBlock(ctx, genesis))
+
+	blocks := getBlocks(t, 4)
+	require.NoError(t, b.ProcessNewBlocks(ctx, blocks))
+
+	// Block 2 window ends at 99: the store holds event2 (time 80 < 99) but the
+	// gate withholds it, so only event1 is mapped. A store-based boundary would
+	// wrongly include event2 here.
+	res, err := b.Events(ctx, blocks[1].Hash(), 2)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, event1Data, res[0].Data())
+
+	// Block 4 window ends at 199 (>= release): event2 is included now.
+	res, err = b.Events(ctx, blocks[3].Hash(), 4)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, event2Data, res[0].Data())
 
 	cancel()
 	wg.Wait()


### PR DESCRIPTION
## Summary

An Erigon RPC node on Amoy crashed on a receipt-root mismatch (bad block) at sprint-start block 40429264 and could not sync past it.

Bor commits state-sync events by querying Heimdall's `clerk/time` endpoint live and consuming its server-side stability gate (the most-recent event group is withheld until a later commit is indexed). Erigon's bridge instead re-derived each block's state-sync window by scanning its pre-scraped local event store with the identical `record_time < to` filter. Because the scraper pulls events ahead of the gate into the store, the store-based selection over-included the withheld group at the sprint boundary — 70 events where the rest of the network committed 60 (ids 36970–37029) — diverging from bor and tripping `receiptHash mismatch` on import. The divergence then cascades until resync.

`ProcessNewBlocks` now derives the window boundary from the same gated `clerk/time` query bor uses (via the existing `eventFetcher`; sequential ids, strict `record_time < to`) instead of `store.LastEventIdWithinWindow`. Event bodies are still read from the local store — only the boundary is gated. The existing scraper-side lag (`stateSyncScraperLag`) addressed *fetching*; this addresses *block-window selection*, which is where the over-inclusion occurred.

Verified against block 40429264: replaying bor's exact `clerk/time` query returns the canonical 60 events; a store scan over the same window yields 70.

## Executed tests

- `go test ./polygon/bridge/` — green, including a new regression test (`TestService_ProcessNewBlocksGatesUnstableEvents`) that fails on the pre-fix store boundary (maps 2 events where 1 is canonical) and passes with the fix.
- `go build ./polygon/...`, `go vet ./polygon/bridge/`, `gofmt` — clean.
- Custom image built from this branch for a kurtosis devnet run; the local devnet was blocked by an unrelated kurtosis CLI version mismatch, so devnet validation is pending CI / a devnet on a current kurtosis.

## Rollout notes

- Consensus-affecting: changes the state-sync set committed per block to match bor. Import/RPC path only; no produce-path change.
- Backwards-compatible — aligns Erigon with bor's canonical behavior; no config or DB schema change.
- Nodes that already diverged need a bridge unwind/resync past the first bad block.
- Adds a live Heimdall dependency to block-window selection; on Heimdall error it returns/retries rather than crashing.
- Version bumped to `v3.6.1-beta2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
