### PR TITLE
docs: announce end of Polygon Labs Erigon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Erigon
 
+> [!WARNING]
+> **Polygon Labs support ended on 1 August 2026.**
+>
+> Polygon Labs no longer maintains or supports this repository and will not
+> provide further releases, bug fixes, security updates, or operational
+> support. Existing deployments are expected to continue syncing only until
+> the next Bor hardfork; this is not a compatibility or support guarantee.
+> Polygon PoS node operators should migrate to
+> [Bor](https://github.com/0xPolygon/bor) before that hardfork.
+
 [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.erigon.tech/)
 [![Blog](https://img.shields.io/badge/blog-up-green)](https://erigon.tech/blog/)
 [![Twitter](https://img.shields.io/twitter/follow/ErigonEth?style=social)](https://x.com/ErigonEth)


### PR DESCRIPTION
## Summary

Add an end-of-support warning to the top of the README. Polygon Labs support ended on 1 August 2026; the notice explains that no further releases, fixes, security updates, or operational support will be provided, that syncing is expected only until the next Bor hardfork without guarantee, and that Polygon PoS node operators should migrate to Bor before then.

## Executed tests

- git diff --check origin/release/3.2-develop...HEAD
- Documentation-only change; no runtime tests required.

## Rollout notes

Documentation-only and non-consensus-affecting. Merge this PR before archiving the repository.